### PR TITLE
Use single space after section number instead of two

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -13,7 +13,7 @@ copyright: |
 
 **This is a pre-release draft of the S/MIME Baseline Requirements (SBR) and is undergoing active editing.  It has not yet been balloted to become a CA/Browser Forum standard.**
 
-## 1.1  Overview
+## 1.1 Overview
 This S/MIME Baseline Requirements document describes an integrated set of technologies, protocols, identity-proofing, lifecycle management, and auditing requirements that are necessary for the issuance and management of Publicly-Trusted S/MIME Certificates.
 
 An S/MIME Certificate for the purposes of this document can be identified by the existence of an Extended Key Usage (EKU) Object Identifier (OID) of 1.3.6.1.5.5.7.3.4 for `emailProtection` and the inclusion of an email address in the Subject, an `Rfc822Name`, or an `otherName` of type `id-on-SmtpUTF8Mailbox` in the `subjectAltName` extension.
@@ -28,7 +28,7 @@ These Requirements do not address all of the issues relevant to the issuance and
 
 These Requirements do not address the issuance or management of Certificates by enterprises that operate their own Public Key Infrastructure for internal purposes only, and for which the Root Certificate is not distributed by any Application Software Supplier. These Requirements are applicable to all Certification Authorities within a chain of trust. They are to be flowed down from the Root CA through successive Subordinate CAs.
 
-## 1.2  Document name and identification
+## 1.2 Document name and identification
 This Certificate Policy contains the Baseline Requirements for the Issuance and Management of Publicly-Trusted S/MIME Certificates, as adopted by the CA/Browser Forum.
 
 The following Certificate Policy identifiers are reserved for use by CAs as a means of asserting compliance with this document (OID arc 2.23.140.1.5) as follows:
@@ -61,20 +61,20 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 
 `{joint-iso-itu-t(2) international-organizations(23) ca-browser-forum(140) certificate-policies(1) smime-baseline(5) individual-validated (4) strict (3)}` (2.23.140.1.5.4.3). 
 
-### 1.2.1  Revisions
+### 1.2.1 Revisions
 
 |Version| Ballot|Description                       | Adopted  | Effective\*  |
 |-------|-------|----------------------------------|----------| -----------|
 |00     |       |Working draft                     |TBD       |TBD         |
 \* Effective Date and Additionally Relevant Compliance Date(s)
   
-## 1.3  PKI participants
+## 1.3 PKI participants
 The CA/Browser Forum is a voluntary organization of Certification Authorities and suppliers of Internet browser and other relying-party software applications including mail user agents (web-based or application based) and email service providers that process S/MIME Certificates.
 
-### 1.3.1  Certification authorities
+### 1.3.1 Certification authorities
 Certification Authority (CA) is defined in [Section 1.6.1](#161-definitions). Current CA Members of the CA/Browser Forum are listed at https://cabforum.org/members.
 
-### 1.3.2  Registration authorities
+### 1.3.2 Registration authorities
 
 With the exception of [Section 3.2.2](#322--validation-of-mailbox-authorization-or-control), the CA MAY delegate the performance of all, or any part, of [Section 3.2](#32-initial-identity-validation) requirements to a Delegated Third Party, provided that the process as a whole fulfills all of the requirements of [Section 3.2](#32-initial-identity-validation).
 
@@ -93,40 +93,40 @@ The CA MAY designate an Enterprise Registration Authority (RA) to verify Certifi
 
 The CA SHALL impose these limitations as a contractual requirement on the Enterprise RA and monitor compliance by the Enterprise RA in accordance with [Section 8.8](#88-review-of-enterprise-ra-or-technically-constrained-subordinate-ca).
 
-### 1.3.3  Subscribers
+### 1.3.3 Subscribers
 As defined in [Section 1.6.1](#16-definitions-and-acronyms).
 
 ### 1.3.4 Relying parties
 “Relying Party” and “Application Software Supplier” are defined in [Section 1.6.1](#16-definitions-and-acronyms). Current Members of the CA/Browser Forum who are Application Software Suppliers are listed at https://cabforum.org/members.
 
-### 1.3.5  Other participants
+### 1.3.5 Other participants
 Other groups that have participated in the development of these Requirements include the CPA Canada WebTrust for Certification Authorities task force.  Participation by CPA Canada does not imply its endorsement, recommendation, or approval of the final product.
 
-## 1.4  Certificate usage
+## 1.4 Certificate usage
 The primary goal of these Requirements is to provide a framework where “reasonable assurance” may be provided to senders and recipients of email messages that the party identified in an S/MIME Certificate has control of the domain or email address being asserted. A variation of this use case is where an individual or organization digitally signs email to establish its authenticity and source of origin.  
 
-### 1.4.1  Appropriate certificate uses
+### 1.4.1 Appropriate certificate uses
 The primary goal of these Requirements is to describe an integrated set of technologies, protocols, identity-proofing, lifecycle management, and auditing requirements for the issuance and management of Publicly-Trusted S/MIME Certificates. These Requirements also serve to inform users and help them to make informed decisions when relying on Certificates.
 
 ### 1.4.2 Prohibited certificate uses
 No stipulation.
 
-## 1.5  Policy administration
+## 1.5 Policy administration
 This document may be revised from time to time, as appropriate, in accordance with procedures adopted by the CA/Browser Forum.  The CA/Browser Forum welcomes recommendations and suggestions regarding this standard by email at questions@cabforum.org. 
 
-### 1.5.1  Organization administering the document
+### 1.5.1 Organization administering the document
 No stipulation.
 
-### 1.5.2  Contact person
+### 1.5.2 Contact person
 Contact information for the CA/Browser Forum is available at https://cabforum.org/leadership/. In this section of a CA’s CPS, the CA shall provide a link to a web page or an email address for contacting the person or persons responsible for operation of the CA, including contact information for entities wishing to submit a Certificate Problem Report.
 
-### 1.5.3  Person determining CPS suitability for the policy
+### 1.5.3 Person determining CPS suitability for the policy
 No stipulation.
 
-### 1.5.4  CPS approval procedures
+### 1.5.4 CPS approval procedures
 No stipulation.
 
-## 1.6  Definitions and acronyms
+## 1.6 Definitions and acronyms
 ###  1.6.1 Definitions
 
 **Affiliate**: A corporation, partnership, joint venture or other entity controlling, controlled by, or under common control with another entity, or an agency, department, political subdivision, or any entity operating under the direct control of a Government Entity.
@@ -381,10 +381,10 @@ The key words “SHALL”, “SHALL NOT”, “REQUIRED”, “SHALL”, “SHAL
 # 2. PUBLICATION AND REPOSITORY RESPONSIBILITIES
 The CA SHALL develop, implement, enforce, and annually update a Certificate Policy and/or Certification Practice Statement (CP and/or CPS) that describes in detail how the CA implements the latest version of these Requirements.
 
-## 2.1  Repositories
+## 2.1 Repositories
 The CA SHALL make revocation information for Subordinate CA Certificates and Subscriber Certificates available in accordance with this Policy.
 
-## 2.2  Publication of certification information
+## 2.2 Publication of certification information
 The CA SHALL publicly disclose its CP and/or CPS through an appropriate and readily accessible online means that is available on a 24x7 basis. The CA SHALL publicly disclose its CA business practices to the extent required by the CA's selected audit scheme (see [Section 8](#8-compliance-audit-and-other-assessments)).
 
 The CP and/or CPS SHALL be structured in accordance with RFC 3647 and SHALL include all material required by RFC 3647.
@@ -393,29 +393,29 @@ The CA SHALL publicly give effect to these Requirements and represent that it wi
 
 > [Name of CA] conforms to the current version of the Baseline Requirements for the Issuance and Management of Publicly-Trusted S/MIME Certificates published at http://www.cabforum.org. In the event of any inconsistency between this document and those Requirements, those Requirements take precedence over this document.
 
-## 2.3  Time or frequency of publication
+## 2.3 Time or frequency of publication
 The CA SHALL develop, implement, enforce, and annually update a CP and/or CPS that describes in detail how the CA implements the latest version of these Requirements. The CA SHALL indicate conformance with this requirement by incrementing the version number and adding a dated changelog entry, even if no other changes are made to the document.
 
-## 2.4  Access controls on repositories
+## 2.4 Access controls on repositories
 The CA shall make its Repository publicly available in a read-only manner.
 
 # 3. IDENTIFICATION AND AUTHENTICATION
 
-## 3.1  Naming
+## 3.1 Naming
 
-### 3.1.1  Types of names
+### 3.1.1 Types of names
 
-### 3.1.2  Need for names to be meaningful
+### 3.1.2 Need for names to be meaningful
 
-### 3.1.3  Anonymity or pseudonymity of subscribers
+### 3.1.3 Anonymity or pseudonymity of subscribers
 
-### 3.1.4  Rules for interpreting various name forms
+### 3.1.4 Rules for interpreting various name forms
 
-### 3.1.5  Uniqueness of names
+### 3.1.5 Uniqueness of names
 
-### 3.1.6  Recognition, authentication, and role of trademarks
+### 3.1.6 Recognition, authentication, and role of trademarks
 
-## 3.2  Initial identity validation
+## 3.2 Initial identity validation
 
 The CA SHALL authenticate the identity attributes of the Subject and their control over the email addresses to be included in the S/MIME Certificate according to the requirements of the following sections:
 
@@ -426,9 +426,9 @@ The CA SHALL authenticate the identity attributes of the Subject and their contr
 | Sponsored | Section 3.2.2 | Section 3.2.3 | Section 3.2.4 | 
 | Individual | Section 3.2.2 | NA | Section 3.2.4 | 
 
-### 3.2.1  Method to prove possession of private key
+### 3.2.1 Method to prove possession of private key
 
-### 3.2.2  Validation of mailbox authorization or control
+### 3.2.2 Validation of mailbox authorization or control
 
 This section defines the permitted processes and procedures for confirming the Applicant's control of the email addresses to be included in issued Certificates. 
 
@@ -442,7 +442,7 @@ The CA's CP/CPS SHALL specify the procedures that the CA employs to perform this
 
 Completed validations of Applicant authority may be valid for the issuance of multiple Certificates over time. In all cases, the validation SHALL have been initiated within the time period specified in the relevant requirement (such as [Section 4.2.1](#421-performing-identification-and-authentication-functions)) prior to Certificate issuance.
 
-#### 3.2.2.1  Validating authority over mailbox via domain
+#### 3.2.2.1 Validating authority over mailbox via domain
 
 The CA may confirm the Applicant, such as an Enterprise RA, has been authorized by the email account holder to act on the account holder’s behalf by verifying the entity's control over the domain portion of the email address to be used in the Certificate.
 
@@ -450,7 +450,7 @@ The CA SHALL use only the approved methods in Section 3.2.2.4 of the TLS Baselin
 
 For purposes of domain validation, the term Applicant includes the Applicant's Parent Company, Subsidiary Company, or Affiliate.
 
-#### 3.2.2.2  Validating control over mailbox via email
+#### 3.2.2.2 Validating control over mailbox via email
 
 The CA may confirm the Applicant's control over each `rfc822Name` or `otherName` of type `id-on-SmtpUTF8Mailbox` to be included in a Certificate by sending a Random Value via email and then receiving a confirming response utilizing the Random Value. 
 
@@ -460,11 +460,11 @@ The Random Value SHALL be unique in each email. The Random Value SHALL remain va
 
 The Random Value SHALL be reset upon each instance of the email sent by the CA and, if intended for additional use as an authentication factor, upon first use.  
 
-#### 3.2.2.3  CAA Records
+#### 3.2.2.3 CAA Records
 
 This version of the S/MIME Baseline Requirements does not require the CA to check for CAA records.  The CAA property tags for issue, issuewild, and iodef as specified in RFC 8659 are not recognized for the issuance of S/MIME Certificates.
 
-### 3.2.3  Authentication of organization identity
+### 3.2.3 Authentication of organization identity
 
 The following requirements must be fulfilled to authenticate Organization identity included in the `organization-validated` and `sponsor-validated` Certificate types.
 
@@ -683,7 +683,7 @@ B.  Confirm the Verified Method of Communication by using it to obtain an affirm
 
 The CA MUST verify that the Applicant has the ability to engage in business by verifying the Applicant's, or Affiliate/Parent/Subsidiary Company's, operational existence.  The CA MAY rely on its verification of a Government Entity's legal existence under [Section 3.2.3.2](#3232-verification-of-applicants-legal-existence-and-identity) as verification of a Government Entity's operational existence.
 
-##### 3.2.3.6.2  Acceptable Methods of Verification
+##### 3.2.3.6.2 Acceptable Methods of Verification
 
 To verify the Applicant's ability to engage in business, the CA MUST verify the operational existence of the Applicant, or its Affiliate/Parent/Subsidiary Company, by:
 
@@ -695,36 +695,36 @@ To verify the Applicant's ability to engage in business, the CA MUST verify the 
 
 4. Relying on a Verified Professional Letter to the effect that the Applicant has an active current Demand Deposit Account with a Regulated Financial Institution.
 
-### 3.2.4  Authentication of individual identity
+### 3.2.4 Authentication of individual identity
 
 The following requirements must be fulfilled to authenticate individual identity included in the `sponsor-validated` and `individual-validated` Certificate types.
 
 
-### 3.2.5  Non-verified subscriber information
+### 3.2.5 Non-verified subscriber information
 
 Subscriber information that has not been verified in accordance with these requirements shall not be included in S/MIME Certificates.
 
 ### 3.2.6 Validation of authority
 
-### 3.2.7  Criteria for interoperation
+### 3.2.7 Criteria for interoperation
 
 The CA SHALL disclose all Cross Certificates that identify the CA as the Subject, provided that the CA arranged for or accepted the establishment of the trust relationship (i.e. the Cross Certificate at issue).
 
-## 3.3  Identification and authentication for re-key requests
+## 3.3 Identification and authentication for re-key requests
 
-### 3.3.1  Identification and authentication for routine re-key
+### 3.3.1 Identification and authentication for routine re-key
 
-### 3.3.2  Identification and authentication for re-key after revocation
+### 3.3.2 Identification and authentication for re-key after revocation
 
 ## 3.4 Identification and authentication for revocation request
 
 # 4.  CERTIFICATE LIFE-CYCLE OPERATIONAL REQUIREMENTS
 
-## 4.1  Certificate Application
+## 4.1 Certificate Application
 
-### 4.1.1  Who can submit a certificate application
+### 4.1.1 Who can submit a certificate application
 
-### 4.1.2  Enrollment process and responsibilities
+### 4.1.2 Enrollment process and responsibilities
 
 ## 4.2 Certificate application processing
 
@@ -740,102 +740,102 @@ After the change to any validation method specified in the TLS Baseline Requirem
 
 ### 4.2.2 Approval or rejection of certificate applications
 
-### 4.2.3  Time to process certificate applications
+### 4.2.3 Time to process certificate applications
 
 No stipulation.
 
-## 4.3  Certificate issuance
+## 4.3 Certificate issuance
 Certificate issuance by the Root CA SHALL require an individual authorized by the CA (i.e. the CA system operator, system officer, or PKI administrator) to deliberately issue a direct command in order for the Root CA to perform a certificate signing operation.
 
-### 4.3.1  CA actions during certificate issuance
+### 4.3.1 CA actions during certificate issuance
 
-### 4.3.2  Notification to subscriber by the CA of issuance of certificate
+### 4.3.2 Notification to subscriber by the CA of issuance of certificate
 
-## 4.4  Certificate acceptance
+## 4.4 Certificate acceptance
 
-### 4.4.1  Conduct constituting certificate acceptance
+### 4.4.1 Conduct constituting certificate acceptance
 
-### 4.4.2  Publication of the certificate by the CA
+### 4.4.2 Publication of the certificate by the CA
 
-### 4.4.3  Notification of certificate issuance by the CA to other entities
+### 4.4.3 Notification of certificate issuance by the CA to other entities
 
 ## 4.5 Key pair and certificate usage
 
-### 4.5.1  Subscriber private key and certificate usage
+### 4.5.1 Subscriber private key and certificate usage
 
-### 4.5.2  Relying party public key and certificate usage
+### 4.5.2 Relying party public key and certificate usage
 
-## 4.6  Certificate renewal
+## 4.6 Certificate renewal
 
-### 4.6.1  Circumstance for certificate renewal
+### 4.6.1 Circumstance for certificate renewal
 No stipulation.
 
-### 4.6.2  Who may request renewal
+### 4.6.2 Who may request renewal
 
 No stipulation.
 
-### 4.6.3  Processing certificate renewal requests
+### 4.6.3 Processing certificate renewal requests
 No stipulation.
 
-### 4.6.4  Notification of new certificate issuance to subscriber
+### 4.6.4 Notification of new certificate issuance to subscriber
 No stipulation.
 
-### 4.6.5  Conduct constituting acceptance of a renewal certificate
+### 4.6.5 Conduct constituting acceptance of a renewal certificate
 No stipulation.
 
-### 4.6.6  Publication of the renewal certificate by the CA
+### 4.6.6 Publication of the renewal certificate by the CA
 No stipulation.
 
-### 4.6.7  Notification of certificate issuance by the CA to other entities
+### 4.6.7 Notification of certificate issuance by the CA to other entities
 No stipulation.
 
-## 4.7  Certificate re-key
+## 4.7 Certificate re-key
 
-### 4.7.1  Circumstance for certificate re-key
+### 4.7.1 Circumstance for certificate re-key
 No stipulation.
 
-### 4.7.2  Who may request certification of a new public key
+### 4.7.2 Who may request certification of a new public key
 No stipulation.
 
-### 4.7.3  Processing certificate re-keying requests
+### 4.7.3 Processing certificate re-keying requests
 No stipulation.
 
-### 4.7.4  Notification of new certificate issuance to subscriber
+### 4.7.4 Notification of new certificate issuance to subscriber
 No stipulation.
 
-### 4.7.5  Conduct constituting acceptance of a re-keyed certificate
+### 4.7.5 Conduct constituting acceptance of a re-keyed certificate
 No stipulation.
 
-### 4.7.6  Publication of the re-keyed certificate by the CA
+### 4.7.6 Publication of the re-keyed certificate by the CA
 No stipulation.
 
-### 4.7.7  Notification of certificate issuance by the CA to other entities
+### 4.7.7 Notification of certificate issuance by the CA to other entities
 No stipulation.
 
-## 4.8  Certificate modification
+## 4.8 Certificate modification
 
-### 4.8.1  Circumstance for certificate modification
+### 4.8.1 Circumstance for certificate modification
 No stipulation.
 
-### 4.8.2  Who may request certificate modification
-### 4.8.3  Processing certificate modification requests
+### 4.8.2 Who may request certificate modification
+### 4.8.3 Processing certificate modification requests
 No stipulation.
 
-### 4.8.4  Notification of new certificate issuance to subscriber
+### 4.8.4 Notification of new certificate issuance to subscriber
 No stipulation.
 
-### 4.8.5  Conduct constituting acceptance of modified certificate
+### 4.8.5 Conduct constituting acceptance of modified certificate
 No stipulation.
 
-### 4.8.6  Publication of the modified certificate by the CA
+### 4.8.6 Publication of the modified certificate by the CA
 No stipulation.
 
-### 4.8.7  Notification of certificate issuance by the CA to other entities
+### 4.8.7 Notification of certificate issuance by the CA to other entities
 No stipulation.
 
-## 4.9  Certificate revocation and suspension
+## 4.9 Certificate revocation and suspension
 
-### 4.9.1  Circumstances for revocation
+### 4.9.1 Circumstances for revocation
 
 #### 4.9.1.1 Reasons for Revoking a Subscriber Certificate
 The CA SHALL revoke a Certificate within 24 hours if one or more of the following occurs:
@@ -871,18 +871,18 @@ The Issuing CA SHALL revoke a Subordinate CA Certificate within seven (7) days i
 7. The Issuing CA or Subordinate CA ceases operations for any reason and has not made arrangements for another CA to provide revocation support for the Certificate;
 8. The Issuing CA's or Subordinate CA's right to issue Certificates under these Requirements expires or is revoked or terminated, unless the Issuing CA has made arrangements to continue maintaining the CRL/OCSP Repository; or
 9. Revocation is required by the Issuing CA's CP and/or CPS.
-### 4.9.2  Who can request revocation
+### 4.9.2 Who can request revocation
 The Subscriber, RA, or Issuing CA can initiate revocation. Additionally, Subscribers, Relying Parties, Application Software Suppliers, and other third parties may submit Certificate Problem Reports informing the issuing CA of reasonable cause to revoke the certificate.
 
-### 4.9.3  Procedure for revocation request
+### 4.9.3 Procedure for revocation request
 The CA SHALL provide a process for Subscribers to request revocation of their own Certificates. The process MUST be described in the CA's CP and/or CPS. The CA SHALL maintain a continuous 24x7 ability to accept and respond to revocation requests and Certificate Problem Reports.
 
 The CA SHALL provide Subscribers, Relying Parties, Application Software Suppliers, and other third parties with clear instructions for reporting suspected Private Key Compromise, Certificate misuse, or other types of fraud, compromise, misuse, inappropriate conduct, or any other matter related to Certificates. The CA SHALL publicly disclose the instructions through a readily accessible online means and in Section 1.5.2 of their CPS.
 
-### 4.9.4  Revocation request grace period
+### 4.9.4 Revocation request grace period
 No stipulation.
 
-### 4.9.5  Time within which CA must process the revocation request
+### 4.9.5 Time within which CA must process the revocation request
 Within 24 hours after receiving a Certificate Problem Report, the CA SHALL investigate the facts and circumstances related to a Certificate Problem Report and provide a preliminary report on its findings to both the Subscriber and the entity who filed the Certificate Problem Report.
 
 After reviewing the facts and circumstances, the CA SHALL work with the Subscriber and any entity reporting the Certificate Problem Report or other revocation-related notice to establish whether or not the certificate will be revoked, and if so, a date which the CA will revoke the certificate. The period from receipt of the Certificate Problem Report or revocation-related notice to published revocation MUST NOT exceed the time frame set forth in [Section 4.9.1.1](#4911-reasons-for-revoking-a-subscriber-certificate). The date selected by the CA SHOULD consider the following criteria:
@@ -893,7 +893,7 @@ After reviewing the facts and circumstances, the CA SHALL work with the Subscrib
 4. The entity making the complaint (for example, a complaint from a law enforcement official that a Web site is engaged in illegal activities should carry more weight than a complaint from a consumer alleging that they didn't receive the goods they ordered); and
 5. Relevant legislation.
    
-### 4.9.6  Revocation checking requirement for relying parties
+### 4.9.6 Revocation checking requirement for relying parties
 No stipulation.
 
 **Note**: Following certificate issuance, a certificate may be revoked for reasons stated in [Section 4.9](#49-certificate-revocation-and-suspension). Therefore, relying parties should check the revocation status of all certificates that contain a CDP or OCSP pointer.
@@ -911,7 +911,7 @@ The value of the `nextUpdate` field MUST NOT be more than twelve months beyond t
 ### 4.9.8 Maximum latency for CRLs
 No stipulation.
 
-### 4.9.9  On-line revocation/status checking availability
+### 4.9.9 On-line revocation/status checking availability
 OCSP responses MUST conform to RFC6960 and/or RFC5019. OCSP responses MUST either:
 
 1. Be signed by the CA that issued the Certificates whose revocation status is being checked, or
@@ -966,7 +966,7 @@ Not applicable.
 ### 4.9.16 Limits on suspension period
 Not applicable.
 
-## 4.10  Certificate status services
+## 4.10 Certificate status services
 
 ### 4.10.1 Operational characteristics
 Revocation entries on a CRL or OCSP Response MUST NOT be removed until after the Expiry Date of the revoked Certificate.
@@ -981,10 +981,10 @@ The CA SHALL maintain a continuous 24x7 ability to respond internally to a high-
 ### 4.10.3 Optional features
 No stipulation.
 
-## 4.11  End of subscription
+## 4.11 End of subscription
 No stipulation.
 
-## 4.12  Key escrow and recovery
+## 4.12 Key escrow and recovery
 
 ### 4.12.1 Key escrow and recovery policy and practices
 
@@ -1017,41 +1017,41 @@ The CA's security program MUST include an annual Risk Assessment that:
 
 Based on the Risk Assessment, the CA SHALL develop, implement, and maintain a security plan consisting of security procedures, measures, and products designed to achieve the objectives set forth above and to manage and control the risks identified during the Risk Assessment, commensurate with the sensitivity of the Certificate Data and Certificate Management Processes. The security plan MUST include administrative, organizational, technical, and physical safeguards appropriate to the sensitivity of the Certificate Data and Certificate Management Processes. The security plan MUST also take into account then-available technology and the cost of implementing the specific measures, and SHALL implement a reasonable level of security appropriate to the harm that might result from a breach of security and the nature of the data to be protected.
 
-## 5.1  Physical controls
+## 5.1 Physical controls
 
-### 5.1.2  Physical access
+### 5.1.2 Physical access
 
-### 5.1.3  Power and air conditioning
+### 5.1.3 Power and air conditioning
 
-### 5.1.4  Water exposures
+### 5.1.4 Water exposures
 
-### 5.1.5  Fire prevention and protection
+### 5.1.5 Fire prevention and protection
 
-### 5.1.6  Media storage
+### 5.1.6 Media storage
 
-### 5.1.7  Waste disposal
+### 5.1.7 Waste disposal
 
-### 5.1.8  Off-site backup
+### 5.1.8 Off-site backup
 
-## 5.2  Procedural controls
+## 5.2 Procedural controls
 
-### 5.2.1  Trusted roles
+### 5.2.1 Trusted roles
 
-### 5.2.2  Number of persons required per task
+### 5.2.2 Number of persons required per task
 The CA Private Key SHALL be backed up, stored, and recovered only by personnel in trusted roles using, at least, dual control in a physically secured environment.
 
-### 5.2.3  Identification and authentication for each role
+### 5.2.3 Identification and authentication for each role
 
-### 5.2.4  Roles requiring separation of duties
+### 5.2.4 Roles requiring separation of duties
 
-## 5.3  Personnel controls
+## 5.3 Personnel controls
 
-### 5.3.1  Qualifications, experience, and clearance requirements
+### 5.3.1 Qualifications, experience, and clearance requirements
 Prior to the engagement of any person in the Certificate Management Process, whether as an employee, agent, or an independent contractor of the CA, the CA SHALL verify the identity and trustworthiness of such person.
 
-### 5.3.2  Background check procedures
+### 5.3.2 Background check procedures
 
-### 5.3.3  Training requirements
+### 5.3.3 Training requirements
 The CA SHALL provide all personnel performing information verification duties with skills-training that covers basic Public Key Infrastructure knowledge, authentication and vetting policies and procedures (including the CA's CP and/or CPS), common threats to the information verification process (including phishing and other social engineering tactics), and these Requirements.
 
 The CA SHALL maintain records of such training and ensure that personnel entrusted with Validation Specialist duties maintain a skill level that enables them to perform such duties satisfactorily.
@@ -1060,21 +1060,21 @@ The CA SHALL document that each Validation Specialist possesses the skills requi
 
 The CA SHALL require all Validation Specialists to pass an examination provided by the CA on the information verification requirements outlined in these Requirements.
 
-### 5.3.4  Retraining frequency and requirements
+### 5.3.4 Retraining frequency and requirements
 All personnel in Trusted roles SHALL maintain skill levels consistent with the CA's training and performance programs.
 
-### 5.3.5  Job rotation frequency and sequence
+### 5.3.5 Job rotation frequency and sequence
 
-### 5.3.6  Sanctions for unauthorized actions
+### 5.3.6 Sanctions for unauthorized actions
 
-### 5.3.7  Independent contractor requirements
+### 5.3.7 Independent contractor requirements
 The CA SHALL verify that the Delegated Third Party's personnel involved in the issuance of a Certificate meet the training and skills requirements of [Section 5.3.3](#533--training-requirements) and the document retention and event logging requirements of [Section 5.4.1](#541-types-of-events-recorded).
 
-### 5.3.8  Documentation supplied to personnel
+### 5.3.8 Documentation supplied to personnel
 
-## 5.4  Audit logging procedures
+## 5.4 Audit logging procedures
 
-### 5.4.1  Types of events recorded
+### 5.4.1 Types of events recorded
 The CA and each Delegated Third Party SHALL record details of the actions taken to process a Certificate Request and to issue a Certificate, including all information generated and documentation received in connection with the Certificate Request; the time and date; and the personnel involved. The CA SHALL make these records available to its Qualified Auditor as proof of the CA’s compliance with these Requirements.
 
 The CA SHALL record at least the following events:
@@ -1109,9 +1109,9 @@ Log records MUST include the following elements:
 2. Identity of the person making the journal record; and
 3. Description of the record.
    
-### 5.4.2  Frequency of processing log
+### 5.4.2 Frequency of processing log
 
-### 5.4.3  Retention period for audit log
+### 5.4.3 Retention period for audit log
 The CA SHALL retain, for at least two years:
 
   1. CA certificate and key lifecycle management event records (as set forth in [Section 5.4.1](#541-types-of-events-recorded) (1)) after the later occurrence of:
@@ -1120,43 +1120,43 @@ The CA SHALL retain, for at least two years:
   2. Subscriber Certificate lifecycle management event records (as set forth in [Section 5.4.1](#541-types-of-events-recorded) (2)) after the revocation or expiration of the Subscriber Certificate;
   3. Any security event records (as set forth in [Section 5.4.1](#541-types-of-events-recorded) (3)) after the event occurred.
 
-### 5.4.4  Protection of audit log
+### 5.4.4 Protection of audit log
 
-### 5.4.5  Audit log backup procedures
+### 5.4.5 Audit log backup procedures
 
-### 5.4.6  Audit collection system (internal vs. external)
+### 5.4.6 Audit collection system (internal vs. external)
 
-### 5.4.7  Notification to event-causing subject
+### 5.4.7 Notification to event-causing subject
 
-### 5.4.8  Vulnerability assessments
+### 5.4.8 Vulnerability assessments
 Additionally, the CA's security program MUST include an annual Risk Assessment that:
 
 1. Identifies foreseeable internal and external threats that could result in unauthorized access, disclosure, misuse, alteration, or destruction of any Certificate Data or Certificate Management Processes;
 2. Assesses the likelihood and potential damage of these threats, taking into consideration the sensitivity of the Certificate Data and Certificate Management Processes; and
 3. Assesses the sufficiency of the policies, procedures, information systems, technology, and other arrangements that the CA has in place to counter such threats.
 
-## 5.5  Records archival
+## 5.5 Records archival
 
-### 5.5.1  Types of records archived
+### 5.5.1 Types of records archived
 
-### 5.5.2  Retention period for archive
+### 5.5.2 Retention period for archive
 The CA SHALL retain all documentation relating to Certificate Requests and the verification thereof, and all Certificates and revocation thereof, for at least seven years after any Certificate based on that documentation ceases to be valid.
 
-### 5.5.3  Protection of archive
+### 5.5.3 Protection of archive
 
-### 5.5.4  Archive backup procedures
+### 5.5.4 Archive backup procedures
 
-### 5.5.5  Requirements for time-stamping of records
+### 5.5.5 Requirements for time-stamping of records
 
-### 5.5.6  Archive collection system (internal or external)
+### 5.5.6 Archive collection system (internal or external)
 
-### 5.5.7  Procedures to obtain and verify archive information
+### 5.5.7 Procedures to obtain and verify archive information
 
-## 5.6  Key changeover
+## 5.6 Key changeover
 
-## 5.7  Compromise and disaster recovery
+## 5.7 Compromise and disaster recovery
 
-### 5.7.1  Incident and compromise handling procedures
+### 5.7.1 Incident and compromise handling procedures
 CA organizations shall have an Incident Response Plan and a Disaster Recovery Plan.
 
 The CA SHALL document a business continuity and disaster recovery procedures designed to notify and reasonably protect Application Software Suppliers, Subscribers, and Relying Parties in the event of a disaster, security compromise, or business failure. The CA is not required to publicly disclose its business continuity plans but SHALL make its business continuity plan and security plans available to the CA's auditors upon request. The CA SHALL annually test, review, and update these procedures.
@@ -1179,19 +1179,19 @@ The business continuity plan MUST include:
 14. The distance of recovery facilities to the CA's main site; and
 15. Procedures for securing its facility to the extent possible during the period of time following a disaster and prior to restoring a secure environment either at the original or a remote site.
 
-### 5.7.2  Computing resources, software, and/or data are corrupted
+### 5.7.2 Computing resources, software, and/or data are corrupted
 
-### 5.7.3  Entity private key compromise procedures
+### 5.7.3 Entity private key compromise procedures
 
-### 5.7.4  Business continuity capabilities after a disaster
+### 5.7.4 Business continuity capabilities after a disaster
 
-## 5.8  CA or RA termination
+## 5.8 CA or RA termination
 
 # 6.  TECHNICAL SECURITY CONTROLS
 
-## 6.1  Key pair generation and installation
+## 6.1 Key pair generation and installation
 
-### 6.1.1  Key pair generation
+### 6.1.1 Key pair generation
 #### 6.1.1.1 CA Key Pair Generation
 
 For CA Key Pairs that are either
@@ -1230,16 +1230,16 @@ The CA SHALL reject a Certificate Request if one or more of the following condit
 4. The CA has previously been made aware that the Applicant's Private Key has suffered a Key Compromise, such as through the provisions of [Section 4.9.1.1](#4911-reasons-for-revoking-a-subscriber-certificate);
 5. The CA is aware of a demonstrated or proven method to easily compute the Applicant's Private Key based on the Public Key (such as a Debian weak key, see <https://wiki.debian.org/SSLkeys>).
 
-### 6.1.2  Private key delivery to subscriber
+### 6.1.2 Private key delivery to subscriber
 Parties other than the Subscriber SHALL NOT archive the Subscriber Private Key without authorization by the Subscriber.
 
 If the CA or any of its designated RAs become aware that a Subscriber's Private Key has been communicated to a person or organization not authorized by the Subscriber, then the CA SHALL revoke all certificates that include the Public Key corresponding to the communicated Private Key.
 
-### 6.1.3  Public key delivery to certificate issuer
+### 6.1.3 Public key delivery to certificate issuer
 
-### 6.1.4  CA public key delivery to relying parties
+### 6.1.4 CA public key delivery to relying parties
 
-### 6.1.5  Key sizes
+### 6.1.5 Key sizes
 For RSA key pairs the CA SHALL:
 
 * Ensure that the modulus size, when encoded, is at least 2048 bits, and;
@@ -1255,13 +1255,13 @@ For EdDSA key pairs, the CA SHALL:
   
 No other algorithms or key sizes are permitted.
 
-### 6.1.6  Public key parameters generation and quality checking
+### 6.1.6 Public key parameters generation and quality checking
 
 For RSA key pairs: the CA SHALL confirm that the value of the public exponent is an odd number equal to 3 or more. Additionally, the public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1. The modulus SHOULD also have the following characteristics: an odd number, not the power of a prime, and have no factors smaller than 752. [Source: Section 5.3.3, NIST SP 800-89]
 
 For ECDSA key pairs: the CA SHOULD confirm the validity of all keys using either the ECC Full Public Key Validation Routine or the ECC Partial Public Key Validation Routine. [Source: Sections 5.6.2.3.2 and 5.6.2.3.3, respectively, of NIST SP 800-56A: Revision 2]
 
-### 6.1.7  Key usage purposes (as per X.509 v3 key usage field)
+### 6.1.7 Key usage purposes (as per X.509 v3 key usage field)
 Private Keys corresponding to Root Certificates MUST NOT be used to sign Certificates except in the following cases:
 
 1. Self-signed Certificates to represent the Root CA itself;
@@ -1269,39 +1269,39 @@ Private Keys corresponding to Root Certificates MUST NOT be used to sign Certifi
 3. Certificates for infrastructure purposes (administrative role certificates, internal CA operational device certificates); and
 4. Certificates for OCSP Response verification.
 
-## 6.2  Private Key Protection and Cryptographic Module Engineering Controls
+## 6.2 Private Key Protection and Cryptographic Module Engineering Controls
 The CA SHALL implement physical and logical safeguards to prevent unauthorized certificate issuance. Protection of the CA Private Key outside the validated system or device specified above MUST consist of physical security, encryption, or a combination of both, implemented in a manner that prevents disclosure of the Private Key. The CA SHALL encrypt its Private Key with an algorithm and key-length that, according to the state of the art, are capable of withstanding cryptanalytic attacks for the residual life of the encrypted key or key part.
 
-### 6.2.1  Cryptographic module standards and controls
+### 6.2.1 Cryptographic module standards and controls
 
-### 6.2.2  Private key (n out of m) multi-person control
+### 6.2.2 Private key (n out of m) multi-person control
 
-### 6.2.3  Private key escrow
+### 6.2.3 Private key escrow
 
-### 6.2.4  Private key backup
+### 6.2.4 Private key backup
 
 See [Section 5.2.2](#522-number-of-persons-required-per-task).
 
-### 6.2.5  Private key archival
+### 6.2.5 Private key archival
 Parties other than the Subordinate CA SHALL NOT archive the Subordinate CA Private Keys without authorization by the Subordinate CA.
 
-### 6.2.6  Private key transfer into or from a cryptographic module
+### 6.2.6 Private key transfer into or from a cryptographic module
 
-### 6.2.7  Private key storage on cryptographic module
+### 6.2.7 Private key storage on cryptographic module
 
-### 6.2.8  Method of activating private key
+### 6.2.8 Method of activating private key
 
-### 6.2.9  Method of deactivating private key
+### 6.2.9 Method of deactivating private key
 
 ### 6.2.10 Method of destroying private key
 
 ### 6.2.11 Cryptographic Module Rating
 
-## 6.3  Other aspects of key pair management
+## 6.3 Other aspects of key pair management
 
-### 6.3.1  Public key archival
+### 6.3.1 Public key archival
 
-### 6.3.2  Certificate operational periods and key pair usage periods
+### 6.3.2 Certificate operational periods and key pair usage periods
 
 | Generation | Maximum Validity Period      | 
 |------|-----------------------|
@@ -1310,37 +1310,37 @@ Parties other than the Subordinate CA SHALL NOT archive the Subordinate CA Priva
 
 For the purpose of calculations, a day is measured as 86,400 seconds. Any amount of time greater than this, including fractional seconds and/or leap seconds, shall represent an additional day. For this reason, Subscriber Certificates SHOULD NOT be issued for the maximum permissible time by default, in order to account for such adjustments.
 
-## 6.4  Activation data
+## 6.4 Activation data
 
-### 6.4.1  Activation data generation and installation
+### 6.4.1 Activation data generation and installation
 
-### 6.4.2  Activation data protection
+### 6.4.2 Activation data protection
 
-### 6.4.3  Other aspects of activation data
+### 6.4.3 Other aspects of activation data
 
-## 6.5  Computer security controls
+## 6.5 Computer security controls
 
-### 6.5.1  Specific computer security technical requirements
+### 6.5.1 Specific computer security technical requirements
 
-### 6.5.2  Computer security rating
+### 6.5.2 Computer security rating
 
-## 6.6  Life cycle technical controls
+## 6.6 Life cycle technical controls
 
-### 6.6.1  System development controls
+### 6.6.1 System development controls
 
-### 6.6.2  Security management controls
+### 6.6.2 Security management controls
 
-### 6.6.3  Life cycle security controls
+### 6.6.3 Life cycle security controls
 
-## 6.7  Network security controls
+## 6.7 Network security controls
 
-## 6.8  Time-stamping
+## 6.8 Time-stamping
 
 # 7.  CERTIFICATE, CRL, AND OCSP PROFILES
 
 **Editor's Note:  The format of Section 7 is undergoing significant change.**
 
-## 7.1  Certificate profile
+## 7.1 Certificate profile
 
 The CA SHALL meet the technical requirements set forth in [Section 2.2](#22--publication-of-certification-information), [Section 6.1.5](#615-key-sizes), and [Section 6.1.6](#616-public-key-parameters-generation-and-quality-checking).
 
@@ -1421,7 +1421,7 @@ h. `authorityKeyIdentifier` (MUST be present)
 
    This extension MUST be present and MUST NOT be marked critical. It MUST contain a `keyIdentifier` field and it MUST NOT contain a `authorityCertIssuer` or `authorityCertSerialNumber` field.
 
-#### 7.1.2.3  Subscriber Certificates
+#### 7.1.2.3 Subscriber Certificates
 
 a. `certificatePolicies` (required)
 
@@ -1646,7 +1646,7 @@ If the signing key is Curve25519, the signature algorithm MUST be id-Ed25519 (OI
 
 If the signing key is Curve448, the signature algorithm MUST be id-Ed448 (OID: 1.3.101.113). When encoded, the `AlgorithmIdentifier` MUST be byte-for-byte identical with the following hex-encoded bytes: `300506032b6571`.
 
-### 7.1.4  Name forms
+### 7.1.4 Name forms
 
 #### 7.1.4.1 Name Encoding
 
@@ -1841,7 +1841,7 @@ c. __Certificate Field:__ `subject:countryName` (OID: 2.5.4.6)
 d. Other Subject Attributes  
    Other attributes MAY be present within the subject field. If present, other attributes MUST contain information that has been verified by the CA.
 
-### 7.1.5  Name constraints
+### 7.1.5 Name constraints
 
 For a Subordinate CA Certificate to be considered Technically Constrained, the certificate MUST include an Extended Key Usage (EKU) extension specifying all extended key usages that the Subordinate CA Certificate is authorized to issue certificates for. The `anyExtendedKeyUsage` KeyPurposeId MUST NOT appear within this extension.
 
@@ -1898,23 +1898,23 @@ A Certificate issued to a Subscriber MUST contain, within the Certificate's `cer
 
 The certificate MAY also contain additional policy identifier(s) defined by the Issuing CA. The issuing CA SHALL document in its CP and/or CPS that the Certificates it issues containing the specified policy identifier(s) are managed in accordance with these requirements.
 
-### 7.1.7  Usage of Policy Constraints extension
+### 7.1.7 Usage of Policy Constraints extension
 
-### 7.1.8  Policy qualifiers syntax and semantics
+### 7.1.8 Policy qualifiers syntax and semantics
 
 ### 7.1.9 Processing semantics for the critical Certificate Policies extension
 
-## 7.2  CRL profile
+## 7.2 CRL profile
 
-### 7.2.1  Version number(s)
+### 7.2.1 Version number(s)
 
-### 7.2.2  CRL and CRL entry extensions
+### 7.2.2 CRL and CRL entry extensions
 
-## 7.3  OCSP profile
+## 7.3 OCSP profile
 
-### 7.3.1  Version number(s)
+### 7.3.1 Version number(s)
 
-### 7.3.2  OCSP extensions
+### 7.3.2 OCSP extensions
 
 # 8. COMPLIANCE AUDIT AND OTHER ASSESSMENTS
 The CA SHALL at all times:
@@ -1925,7 +1925,7 @@ The CA SHALL at all times:
 4. Be licensed as a CA in each jurisdiction where it operates, if licensing is required by the law of such jurisdiction for the issuance of Certificates.
 
 **Implementers' Note**: The CA/Browser Forum continues to improve the S/MIME Baseline Requirements while WebTrust and ETSI also continue to update their audit criteria. We encourage all CAs to conform to each revision herein on the date specified without awaiting a corresponding update to an applicable audit criterion. In the event of a conflict between an existing audit criterion and a guideline revision, we will communicate with the audit community and attempt to resolve any uncertainty, and we will respond to implementation questions directed to <questions@cabforum.org>. 
-## 8.1  Frequency or circumstances of assessment
+## 8.1 Frequency or circumstances of assessment
 Certificates that are capable of being used to issue new certificates MUST either be Technically Constrained in line with [Section 7.1.5](#715-name-constraints) and audited in line with [Section 8.8](#88-review-of-enterprise-ra-or-technically-constrained-subordinate-ca) only, or Unconstrained and fully audited in line with all remaining requirements from this section. A Certificate is deemed as capable of being used to issue new certificates if it contains an X.509v3 `basicConstraints` extension, with the `cA` boolean set to true and is therefore by definition a Root CA Certificate or a Subordinate CA Certificate.
 
 The period during which the CA issues Certificates SHALL be divided into an unbroken sequence of audit periods. An audit period MUST NOT exceed one year in duration.
@@ -1934,7 +1934,7 @@ If the CA has a currently valid Audit Report indicating compliance with an audit
 
 If the CA does not have a currently valid Audit Report indicating compliance with one of the audit schemes listed in [Section 8.4](#84-topics-covered-by-assessment), then, before issuing Publicly-Trusted Certificates, the CA SHALL successfully complete a point-in-time readiness assessment performed in accordance with applicable standards under one of the audit schemes listed in [Section 8.4](#84-topics-covered-by-assessment). The point-in-time readiness assessment SHALL be completed no earlier than twelve (12) months prior to issuing Publicly-Trusted Certificates and SHALL be followed by a complete audit under such scheme within ninety (90) days of issuing the first Publicly-Trusted Certificate.
 
-## 8.2  Identity/qualifications of assessor
+## 8.2 Identity/qualifications of assessor
 The CA's audit SHALL be performed by a Qualified Auditor. A Qualified Auditor means a natural person, Legal Entity, or group of natural persons or Legal Entities that collectively possess the following qualifications and skills:
 
 1. Independence from the subject of the audit;
@@ -1945,9 +1945,9 @@ The CA's audit SHALL be performed by a Qualified Auditor. A Qualified Auditor me
 6. Bound by law, government regulation, or professional code of ethics; and
 7. Except in the case of an Internal Government Auditing Agency, maintains Professional Liability/Errors & Omissions insurance with policy limits of at least one million US dollars in coverage.
    
-## 8.3  Assessor's relationship to assessed entity
+## 8.3 Assessor's relationship to assessed entity
 
-## 8.4  Topics covered by assessment
+## 8.4 Topics covered by assessment
 The CA SHALL undergo an audit in accordance with one of the following schemes:
 
 1. “WebTrust for CAs v2.1 or newer” AND “XXXX or newer”; or
@@ -1963,9 +1963,9 @@ For Delegated Third Parties which are not Enterprise RAs, then the CA SHALL obta
 
 The audit period for the Delegated Third Party SHALL NOT exceed one year (ideally aligned with the CA's audit). However, if the CA or Delegated Third Party is under the operation, control, or supervision of a Government Entity and the audit scheme is completed over multiple years, then the annual audit MUST cover at least the core controls that are required to be audited annually by such scheme plus that portion of all non-core controls that are allowed to be conducted less frequently, but in no case may any non-core control be audited less often than once every three years.
 
-## 8.5  Actions taken as a result of deficiency
+## 8.5 Actions taken as a result of deficiency
 
-## 8.6  Communication of results
+## 8.6 Communication of results
 The Audit Report SHALL state explicitly that it covers the relevant systems and processes used in the issuance of all Certificates that assert one or more of the policy identifiers listed in [Section 7.1.6.1](#7161-reserved-certificate-policy-identifiers). The CA SHALL make the Audit Report publicly available.
 
 The CA MUST make its Audit Report publicly available no later than three months after the end of the audit period. In the event of a delay greater than three months, the CA SHALL provide an explanatory letter signed by the Qualified Auditor.
@@ -2000,55 +2000,55 @@ The CA SHALL internally audit the compliance of Delegated Third Parties, Enterpr
 
 # 9. OTHER BUSINESS AND LEGAL MATTERS
 
-## 9.1  Fees
+## 9.1 Fees
 
-### 9.1.1  Certificate issuance or renewal fees
+### 9.1.1 Certificate issuance or renewal fees
 
-### 9.1.2  Certificate access fees
+### 9.1.2 Certificate access fees
 
-### 9.1.3  Revocation or status information access fees
+### 9.1.3 Revocation or status information access fees
 
-### 9.1.4  Fees for other services
+### 9.1.4 Fees for other services
 
-### 9.1.5  Refund policy
+### 9.1.5 Refund policy
 
-## 9.2  Financial responsibility
+## 9.2 Financial responsibility
 
-### 9.2.1  Insurance coverage
+### 9.2.1 Insurance coverage
 
-### 9.2.2  Other assets
+### 9.2.2 Other assets
 
-### 9.2.3  Insurance or warranty coverage for end-entities
+### 9.2.3 Insurance or warranty coverage for end-entities
 
-## 9.3  Confidentiality of business information
+## 9.3 Confidentiality of business information
 
-### 9.3.1  Scope of confidential information
+### 9.3.1 Scope of confidential information
 
-### 9.3.2  Information not within the scope of confidential information
+### 9.3.2 Information not within the scope of confidential information
 
-### 9.3.3  Responsibility to protect confidential information
+### 9.3.3 Responsibility to protect confidential information
 
-## 9.4  Privacy of personal information
+## 9.4 Privacy of personal information
 
-### 9.4.1  Privacy plan
+### 9.4.1 Privacy plan
 
-### 9.4.2  Information treated as private
+### 9.4.2 Information treated as private
 
-### 9.4.3  Information not deemed private
+### 9.4.3 Information not deemed private
 
-### 9.4.4  Responsibility to protect private information
+### 9.4.4 Responsibility to protect private information
 
-### 9.4.5  Notice and consent to use private information
+### 9.4.5 Notice and consent to use private information
 
 ### 9.4.6 Disclosure pursuant to judicial or administrative process
 
-### 9.4.7  Other information disclosure circumstances
+### 9.4.7 Other information disclosure circumstances
 
-## 9.5  Intellectual property rights
+## 9.5 Intellectual property rights
 
-## 9.6  Representations and warranties
+## 9.6 Representations and warranties
 
-### 9.6.1  CA representations and warranties
+### 9.6.1 CA representations and warranties
 
 For any Certificate in a hierarchy capable of being used for S/MIME, CAs SHALL revoke Certificates upon the occurrence of any of the following events:
 
@@ -2065,55 +2065,55 @@ For any Certificate in a hierarchy capable of being used for S/MIME, CAs SHALL r
 11. such additional revocation events as the CA publishes in its policy documentation; or
 12. the Certificate was issued in violation of the then-current version of these requirements.
 
-### 9.6.2  RA representations and warranties
+### 9.6.2 RA representations and warranties
 
-### 9.6.3  Subscriber representations and warranties
+### 9.6.3 Subscriber representations and warranties
 
-### 9.6.4  Relying party representations and warranties
+### 9.6.4 Relying party representations and warranties
 
-### 9.6.5  Representations and warranties of other participants
+### 9.6.5 Representations and warranties of other participants
 
-## 9.7  Disclaimers of warranties
+## 9.7 Disclaimers of warranties
 
-## 9.8  Limitations of liability
+## 9.8 Limitations of liability
 For delegated tasks, the CA and any Delegated Third Party MAY allocate liability between themselves contractually as they determine, but the CA SHALL remain fully responsible for the performance of all parties in accordance with these Requirements, as if the tasks had not been delegated.
 
 If the CA has issued and managed the Certificate in compliance with these Requirements and its CP and/or CPS, the CA MAY disclaim liability to the Certificate Beneficiaries or any other third parties for any losses suffered as a result of use or reliance on such Certificate beyond those specified in the CA's CP and/or CPS. If the CA has not issued or managed the Certificate in compliance with these Requirements and its CP and/or CPS, the CA MAY seek to limit its liability to the Subscriber and to Relying Parties, regardless of the cause of action or legal theory involved, for any and all claims, losses or damages suffered as a result of the use or reliance on such Certificate by any appropriate means that the CA desires. If the CA chooses to limit its liability for Certificates that are not issued or managed in compliance with these Requirements or its CP and/or CPS, then the CA SHALL include the limitations on liability in the CA's CP and/or CPS.
 
-## 9.9  Indemnities
+## 9.9 Indemnities
 Notwithstanding any limitations on its liability to Subscribers and Relying Parties, the CA understands and acknowledges that the Application Software Suppliers who have a Root Certificate distribution agreement in place with the Root CA do not assume any obligation or potential liability of the CA under these Requirements or that otherwise might exist because of the issuance or maintenance of Certificates or reliance thereon by Relying Parties or others. Thus, except in the case where the CA is a government entity, the CA SHALL defend, indemnify, and hold harmless each Application Software Supplier for any and all claims, damages, and losses suffered by such Application Software Supplier related to a Certificate issued by the CA, regardless of the cause of action or legal theory involved. This does not apply, however, to any claim, damages, or loss suffered by such Application Software Supplier related to a Certificate issued by the CA where such claim, damage, or loss was directly caused by such Application Software Supplier's software displaying as not trustworthy a Certificate that is still valid, or displaying as trustworthy: (1) a Certificate that has expired, or (2) a Certificate that has been revoked (but only in cases where the revocation status is currently available from the CA online, and the application software either failed to check such status or ignored an indication of revoked status).
 
-## 9.10  Term and termination
+## 9.10 Term and termination
 
-### 9.10.1  Term
+### 9.10.1 Term
 
-### 9.10.2  Termination
+### 9.10.2 Termination
 
-### 9.10.3  Effect of termination and survival
+### 9.10.3 Effect of termination and survival
 
-## 9.11  Individual notices and communications with participants
+## 9.11 Individual notices and communications with participants
 
-## 9.12  Amendments
+## 9.12 Amendments
 
-### 9.12.1  Procedure for amendment
+### 9.12.1 Procedure for amendment
 
-### 9.12.2  Notification mechanism and period
+### 9.12.2 Notification mechanism and period
 
-### 9.12.3  Circumstances under which OID must be changed
+### 9.12.3 Circumstances under which OID must be changed
 
-## 9.13  Dispute resolution provisions
+## 9.13 Dispute resolution provisions
 
-## 9.14  Governing law
+## 9.14 Governing law
 
-## 9.15  Compliance with applicable law
+## 9.15 Compliance with applicable law
 
-## 9.16  Miscellaneous provisions
+## 9.16 Miscellaneous provisions
 
-### 9.16.1  Entire agreement
+### 9.16.1 Entire agreement
 
-### 9.16.2  Assignment
+### 9.16.2 Assignment
 
-### 9.16.3  Severability
+### 9.16.3 Severability
 
 In the event of a conflict between these Requirements and a law, regulation or government order (hereinafter ‘Law’) of any jurisdiction in which a CA operates or issues certificates, a CA MAY modify any conflicting requirement to the minimum extent necessary to make the requirement valid and legal in the jurisdiction. This applies only to operations or certificate issuances that are subject to that Law. In such event, the CA SHALL immediately (and prior to issuing a certificate under the modified requirement) include in Section 9.16.3 of the CA’s CPS a detailed reference to the Law requiring a modification of these Requirements under this section, and the specific modification to these Requirements implemented by the CA.
 
@@ -2121,11 +2121,11 @@ The CA SHALL also (prior to issuing a certificate under the modified requirement
 
 Any modification to CA practice enabled under this section SHALL be discontinued if and when the Law no longer applies, or these Requirements are modified to make it possible to comply with both them and the Law simultaneously. An appropriate change in practice, modification to the CA’s CPS and a notice to the CA/Browser Forum, as outlined above, SHALL be made within 90 days.
 
-### 9.16.4  Enforcement (attorneys' fees and waiver of rights)
+### 9.16.4 Enforcement (attorneys' fees and waiver of rights)
 
-### 9.16.5  Force Majeure
+### 9.16.5 Force Majeure
 
-## 9.17  Other provisions
+## 9.17 Other provisions
 
 ## A.1 Reference Sources
 


### PR DESCRIPTION
This fixes the broken Github Markdown links.