### PR TITLE
Added validation of applicant as operator of associated mail server.

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -463,7 +463,7 @@ The Random Value SHALL be reset upon each instance of the email sent by the CA a
 
 #### 3.2.2.3 Validating applicant as operator of associated mail server(s)
 
-Confirming the Applicant's control over the rfc822Name email address by confirming control of the SMTP FQDN to which a message delivered to the email address should be directed. The SMTP FQDN MUST be identified using the address resolution algorithm defined in RFC 5321 Section 5.1 which determines which SMTP FQDNs are authoritative for a given email address. If more than one SMTP FQDNs have been discovered, the CA MUST verify control of an SMTP FQDN following the selection process at RFC 5321 Section 5.1.
+Confirming the Applicant's control over the `rfc822Name` or `otherName` of type `id-on-SmtpUTF8Mailbox` email address by confirming control of the SMTP FQDN to which a message delivered to the email address should be directed. The SMTP FQDN MUST be identified using the address resolution algorithm defined in RFC 5321 Section 5.1 which determines which SMTP FQDNs are authoritative for a given email address. If more than one SMTP FQDNs have been discovered, the CA MUST verify control of an SMTP FQDN following the selection process at RFC 5321 Section 5.1.
 
 When confirming the Applicant's control of the SMTP FQDN, the CA MUST use the methods in Section 3.2.2.4 of the Baseline Requirements for the Issuance and Management of Publicly‐Trusted Certificates.
 

--- a/SBR.md
+++ b/SBR.md
@@ -463,7 +463,7 @@ The Random Value SHALL be reset upon each instance of the email sent by the CA a
 
 #### 3.2.2.3 Validating applicant as operator of associated mail server(s)
 
-Confirming the Applicant's control over the `rfc822Name` or `otherName` of type `id-on-SmtpUTF8Mailbox` email address by confirming control of the SMTP FQDN to which a message delivered to the email address should be directed. The SMTP FQDN MUST be identified using the address resolution algorithm defined in RFC 5321 Section 5.1 which determines which SMTP FQDNs are authoritative for a given email address. If more than one SMTP FQDNs have been discovered, the CA MUST verify control of an SMTP FQDN following the selection process at RFC 5321 Section 5.1.
+Confirming the Applicant's control over the `rfc822Name` or `otherName` of type `id-on-SmtpUTF8Mailbox` email address by confirming control of the SMTP FQDN to which a message delivered to the email address should be directed. The SMTP FQDN MUST be identified using the address resolution algorithm defined in RFC 5321 Section 5.1 which determines which SMTP FQDNs are authoritative for a given email address. If more than one SMTP FQDNs have been discovered, the CA MUST verify control of an SMTP FQDN following the selection process at RFC 5321 Section 5.1. Aliases in MX record RDATA MUST NOT be used for this validation method.
 
 When confirming the Applicant's control of the SMTP FQDN, the CA MUST use the methods in Section 3.2.2.4 of the Baseline Requirements for the Issuance and Management of Publicly‐Trusted Certificates.
 

--- a/SBR.md
+++ b/SBR.md
@@ -372,7 +372,8 @@ The script outputs:
 |TLS	   |Transport Layer Security|
 
 ###  1.6.3 References
-TBD
+
+RFC 5321, Request for Comments: 5321, Simple Mail Transfer Protocol, J. Klensin, October 2008.
 
 ###  1.6.4 Conventions
 
@@ -460,7 +461,15 @@ The Random Value SHALL be unique in each email. The Random Value SHALL remain va
 
 The Random Value SHALL be reset upon each instance of the email sent by the CA and, if intended for additional use as an authentication factor, upon first use.  
 
-#### 3.2.2.3 CAA Records
+#### 3.2.2.3 Validating applicant as operator of associated mail server(s)
+
+Confirming the Applicant's control over the rfc822Name email address by confirming control of the SMTP FQDN to which a message delivered to the email address should be directed. The SMTP FQDN MUST be identified using the address resolution algorithm defined in RFC 5321 Section 5.1 which determines which SMTP FQDNs are authoritative for a given email address. If more than one SMTP FQDNs have been discovered, the CA MUST verify control of an SMTP FQDN following the selection process at RFC 5321 Section 5.1.
+
+When confirming the Applicant's control of the SMTP FQDN, the CA MUST use the methods in Section 3.2.2.4 of the Baseline Requirements for the Issuance and Management of Publicly‐Trusted Certificates.
+
+This method is suitable for validating control of all email addresses under a single domain.
+
+#### 3.2.2.4 CAA Records
 
 This version of the S/MIME Baseline Requirements does not require the CA to check for CAA records.  The CAA property tags for issue, issuewild, and iodef as specified in RFC 8659 are not recognized for the issuance of S/MIME Certificates.
 


### PR DESCRIPTION
A new validation method has been added that allows validation of all email addresses under a single domain by confirming that the Applicant has control of the SMTP FQDN to which all messages are delivered.