### PR TITLE
Remove subject:JOI requirements from disclosure

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -610,7 +610,6 @@ Prior to the use of an Incorporating Agency or Registration Agency to fulfill th
 This Agency Information SHALL include at least the following:
 
 * Sufficient information to unambiguously identify the Incorporating Agency or Registration Agency (such as a name, jurisdiction, and website); 
-* The accepted value or values for each of the `subject:jurisdictionLocalityName` (OID: 1.3.6.1.4.1.311.60.2.1.1), `subject:jurisdictionStateOrProvinceName` (OID: 1.3.6.1.4.1.311.60.2.1.2), and `subject:jurisdictionCountryName` (OID: 1.3.6.1.4.1.311.60.2.1.3) fields, when a Certificate is issued using information from that Incorporating Agency or Registration Agency, indicating the jurisdiction(s) that the Agency is appropriate for; 
 * The acceptable form or syntax of Registration Numbers used by the Incorporating Agency or Registration Agency, if the CA restricts such Numbers to an acceptable form or syntax; and
 * A revision history that includes a unique version number and date of publication for any additions, modifications, and/or removals from this list.
 


### PR DESCRIPTION
Since the subject:joi fields in question are not allowed in MultiPurpose and Strict profiles, remove the requirement for allowed values

Relates to issue #58 