### PR TITLE
#137 OCSP either/or CRL

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -1716,15 +1716,27 @@ a. `certificatePolicies` (SHALL be present)
 
    If the value of this extension includes a `PolicyInformation` which contains a qualifier of type `id-qt-cps` (OID: 1.3.6.1.5.5.7.2.1), then the value of the qualifier SHALL be a HTTP or HTTPS URL for the Issuing CA's CP and/or CPS, Relying Party Agreement, or other pointer to online policy information provided by the Issuing CA. If a qualifier of type `id-qt-unotice` (OID: 1.3.6.1.5.5.7.2.2) is included, then it SHALL contain `explicitText` and SHALL NOT contain `noticeRef`. 
 
-b. `cRLDistributionPoints` (SHALL be present)
+b. `cRLDistributionPoints` 
 
-   This extension SHOULD NOT be marked critical. It SHALL contain at least one `distributionPoint` whose `fullName` value includes a GeneralName of type `uniformResourceIdentifier` that includes a HTTP URI where the Issuing CA's CRL can be retrieved. For Legacy profiles only, additional publicly accessible `fullName` LDAP, FTP, or HTTP URIs MAY be specified.
+   This extension MAY be present if the `authorityInformationAccess` extension is present and has at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
+   
+   This extension SHALL be present if the `authorityInformationAccess` extension is missing.
+   
+   This extension SHALL be present if the `authorityInformationAccess` extension does not have at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
+   
+   This extension SHOULD NOT be marked critical. If present, it SHALL contain at least one `distributionPoint` whose `fullName` value includes a GeneralName of type `uniformResourceIdentifier` that includes a HTTP URI where the Issuing CA's CRL can be retrieved. For Legacy profiles only, additional publicly accessible `fullName` LDAP, FTP, or HTTP URIs MAY be specified.
 
-c. `authorityInformationAccess` (SHALL be present)
+c. `authorityInformationAccess` (SHOULD be present if the `cRLDistributionPoints` extension is present. SHALL be present if the `cRLDistributionPoints` extension is missing)
 
-   This extension SHALL NOT be marked critical, and it SHALL contain at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. For Legacy profiles only, additional publicly accessible `id-ad-ocsp` LDAP, FTP, or HTTP URIs MAY be specified. 
+   This extension SHALL NOT be marked critical. 
    
    This extension SHOULD contain at least one `accessMethod` value of type `id-ad-caIssuers` that specifies the HTTP URI of the Issuing CA's Certificate. For Legacy profiles only, additional publicly accessible `id-ad-caIssuers` LDAP, FTP, or HTTP URIs MAY be specified.
+
+   If the `cRLDistributionPoints` extension is present, the `authorityInformationAccess` extension SHOULD contain at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
+
+   If the `cRLDistributionPoints` extension is missing, the `authorityInformationAccess` extension SHALL contain at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
+   
+   For Legacy profiles only, additional publicly accessible `id-ad-ocsp` LDAP, FTP, or HTTP URIs MAY be specified. 
 
 d. `basicConstraints` (optional)
 

--- a/SBR.md
+++ b/SBR.md
@@ -1724,7 +1724,8 @@ b. `cRLDistributionPoints`
    
    This extension SHALL be present if the `authorityInformationAccess` extension does not have at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
    
-   This extension SHOULD NOT be marked critical. If present, it SHALL contain at least one `distributionPoint` field whose `fullName` value includes a GeneralName of type `uniformResourceIdentifier` that includes a HTTP URI where the Issuing CA's CRL can be retrieved. For Legacy profiles only, additional publicly accessible `fullName` LDAP or FTP URIs MAY be specified.
+   This extension SHOULD NOT be marked critical. If present, it SHALL contain at least one `distributionPoint` field whose `fullName` value includes a GeneralName of type `uniformResourceIdentifier` that includes a HTTP URI where the Issuing CA's CRL can be retrieved. 
+   For Legacy profiles only, additional publicly accessible `fullName` LDAP or FTP URIs MAY be specified.
    For all profiles, additional publicly accessible `fullName` HTTP URIs MAY be specified.
 
 c. `authorityInformationAccess` (SHOULD be present if the `cRLDistributionPoints` extension is present. SHALL be present if the `cRLDistributionPoints` extension is missing)

--- a/SBR.md
+++ b/SBR.md
@@ -1724,7 +1724,8 @@ b. `cRLDistributionPoints`
    
    This extension SHALL be present if the `authorityInformationAccess` extension does not have at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
    
-   This extension SHOULD NOT be marked critical. If present, it SHALL contain at least one `distributionPoint` whose `fullName` value includes a GeneralName of type `uniformResourceIdentifier` that includes a HTTP URI where the Issuing CA's CRL can be retrieved. For Legacy profiles only, additional publicly accessible `fullName` LDAP, FTP, or HTTP URIs MAY be specified.
+   This extension SHOULD NOT be marked critical. If present, it SHALL contain at least one `distributionPoint` field whose `fullName` value includes a GeneralName of type `uniformResourceIdentifier` that includes a HTTP URI where the Issuing CA's CRL can be retrieved. For Legacy profiles only, additional publicly accessible `fullName` LDAP or FTP URIs MAY be specified.
+   For all profiles, additional publicly accessible `fullName` HTTP URIs MAY be specified.
 
 c. `authorityInformationAccess` (SHOULD be present if the `cRLDistributionPoints` extension is present. SHALL be present if the `cRLDistributionPoints` extension is missing)
 
@@ -1736,7 +1737,8 @@ c. `authorityInformationAccess` (SHOULD be present if the `cRLDistributionPoints
 
    If the `cRLDistributionPoints` extension is missing, the `authorityInformationAccess` extension SHALL contain at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
    
-   For Legacy profiles only, additional publicly accessible `id-ad-ocsp` LDAP, FTP, or HTTP URIs MAY be specified. 
+   For Legacy profiles only, additional publicly accessible `id-ad-ocsp` LDAP or FTP URIs MAY be specified. 
+   For all profiles, additional publicly accessible `id-ad-ocsp` HTTP URIs MAY be specified. 
 
 d. `basicConstraints` (optional)
 

--- a/SBR.md
+++ b/SBR.md
@@ -1716,30 +1716,17 @@ a. `certificatePolicies` (SHALL be present)
 
    If the value of this extension includes a `PolicyInformation` which contains a qualifier of type `id-qt-cps` (OID: 1.3.6.1.5.5.7.2.1), then the value of the qualifier SHALL be a HTTP or HTTPS URL for the Issuing CA's CP and/or CPS, Relying Party Agreement, or other pointer to online policy information provided by the Issuing CA. If a qualifier of type `id-qt-unotice` (OID: 1.3.6.1.5.5.7.2.2) is included, then it SHALL contain `explicitText` and SHALL NOT contain `noticeRef`. 
 
-b. `cRLDistributionPoints` 
-
-   This extension MAY be present if the `authorityInformationAccess` extension is present and has at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
-   
-   This extension SHALL be present if the `authorityInformationAccess` extension is missing.
-   
-   This extension SHALL be present if the `authorityInformationAccess` extension does not have at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
+b. `cRLDistributionPoints` (SHALL be present)
    
    This extension SHOULD NOT be marked critical. If present, it SHALL contain at least one `distributionPoint` field whose `fullName` value includes a GeneralName of type `uniformResourceIdentifier` that includes a HTTP URI where the Issuing CA's CRL can be retrieved. 
-   For Legacy profiles only, additional publicly accessible `fullName` LDAP or FTP URIs MAY be specified.
-   For all profiles, additional publicly accessible `fullName` HTTP URIs MAY be specified.
+   
+   For Legacy profiles only, additional publicly accessible `fullName` LDAP or FTP URIs MAY be specified. For all Generation profiles, additional publicly accessible `fullName` HTTP URIs MAY be specified.
 
-c. `authorityInformationAccess` (SHOULD be present if the `cRLDistributionPoints` extension is present. SHALL be present if the `cRLDistributionPoints` extension is missing)
+c. `authorityInformationAccess` (SHALL be present)
 
-   This extension SHALL NOT be marked critical. 
+   This extension SHALL NOT be marked critical, and it SHALL contain at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. For Legacy profiles only, additional publicly accessible `id-ad-ocsp` LDAP or FTP URIs MAY be specified. For all Generation profiles, additional publicly accessible `id-ad-ocsp` HTTP URIs MAY be specified. 
    
    This extension SHOULD contain at least one `accessMethod` value of type `id-ad-caIssuers` that specifies the HTTP URI of the Issuing CA's Certificate. For Legacy profiles only, additional publicly accessible `id-ad-caIssuers` LDAP, FTP, or HTTP URIs MAY be specified.
-
-   If the `cRLDistributionPoints` extension is present, the `authorityInformationAccess` extension SHOULD contain at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
-
-   If the `cRLDistributionPoints` extension is missing, the `authorityInformationAccess` extension SHALL contain at least one `accessMethod` value of type `id-ad-ocsp` that specifies the HTTP URI of the Issuing CA's OCSP responder. 
-   
-   For Legacy profiles only, additional publicly accessible `id-ad-ocsp` LDAP or FTP URIs MAY be specified. 
-   For all profiles, additional publicly accessible `id-ad-ocsp` HTTP URIs MAY be specified. 
 
 d. `basicConstraints` (optional)
 


### PR DESCRIPTION
Includes language to require that either OCSP or CRL is required at anyt ime. Both are allowed. OCSP preferred.

Also includes a changes that will allow the use of multiple HTTP URIs for CRL and OCSP, which previously was for Legacy profiles.
LDAP/FTP still only for Legacy