### PR TITLE
Logging of signatures of OCSP responses removed

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -1287,17 +1287,15 @@ The CA SHALL record at least the following events:
    ii. Certificate requests, renewal, and re-key requests, and revocation;
    iii. Approval and rejection of Certificate Requests;
    iv. Cryptographic device lifecycle management events;
-   v. Generation of Certificate Revocation Lists;
-   vi. Signing of OCSP Responses (as described in [Section 4.9](#49-certificate-revocation-and-suspension) and [Section 4.10](#410-certificate-status-services)); and
-   vii. Introduction of new Certificate Profiles and retirement of existing Certificate Profiles.
+   v. Generation of Certificate Revocation Lists; and
+   vi. Introduction of new Certificate Profiles and retirement of existing Certificate Profiles.
 
 2. Subscriber Certificate lifecycle management events, including:<br>
    i. Certificate requests, renewal, and re-key requests, and revocation;
    ii. All verification activities stipulated in these Requirements and the CA's Certification Practice Statement;
    iii. Approval and rejection of Certificate Requests;
-   iv. Issuance of Certificates;
-   v. Generation of Certificate Revocation Lists; and
-   vi. Signing of OCSP Responses (as described in [Section 4.9](#49-certificate-revocation-and-suspension) and [Section 4.10](#410-certificate-status-services)).
+   iv. Issuance of Certificates; and
+   v. Generation of Certificate Revocation Lists.
 
 3. Security events, including:<br>
    i. Successful and unsuccessful PKI system access attempts;


### PR DESCRIPTION
I don't believe it is reasonable to log every event, when the OCSP responder signs an OCSP response.