### PR TITLE
Define "Assumed Name"

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -173,6 +173,8 @@ The Definitions found in the [CA/Browser Forum's Network and Certificate System 
 
 **Application Software Supplier**: A supplier of email client software or other relying-party application software such as mail user agents (web-based or application based) and email service providers that process S/MIME Certificates.
 
+**Assumed Name**: A pseudonym used by companies that do not operate under their registered company name.
+
 **Attestation**: A letter attesting that Subject Information is correct written by an accountant, lawyer, government official, or other reliable third party customarily relied upon for such information.
 
 **Audit Period**: In a period-of-time audit, the period between the first day (start) and the last day of operations (end) covered by the auditors in their engagement. (This is not the same as the period of time when the auditors are on-site at the CA.) The coverage rules and maximum length of audit periods are defined in [Section 8.1](#81-frequency-or-circumstances-of-assessment).


### PR DESCRIPTION
As the concept of "Assumed Name" or "DBA" is not widely known outside of the USA we should clarify its meaning. The proposed definition comes from https://en.wikipedia.org/wiki/Trade_name .