### PR TITLE
v1.0.9 - Ballot SMC011

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -7,7 +7,7 @@ jobs:
         document:
           - 'SBR.md'
     name: Build ${{ matrix.document }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3

--- a/SBR.md
+++ b/SBR.md
@@ -2236,7 +2236,7 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
 
    **Note 3**: For the NTR Registration Scheme, where the Legal Entity is registered within a European country, the NTR Registration Scheme SHALL be assigned at the country level.
 
-   **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the EUID MAY be used as the Registration Reference. In Germany, the EUID SHOULD be used as the Registration Reference. See [Appendix A.1](#a1-organizationidentifier).The structure of the EUID SHALL be as follows:
+   **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the EUID MAY be used as the Registration Reference. In Germany, the EUID SHOULD be used as the Registration Reference. The structure of the EUID SHALL be as follows:
 
    * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
    * the register identifier, for the (member state) domestic register;

--- a/SBR.md
+++ b/SBR.md
@@ -2258,7 +2258,7 @@ If the Registration Reference is assigned at the subdivision (state or province)
     * the Registration Reference allocated by the domestic register.
   
     For example:
-    * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the business register ID for the district court in Cologne, and HRB12345 is the locally-assigned Registration Reference).
+    * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the business register identifier for the district court in Cologne, and HRB12345 is the locally-assigned Registration Reference).
 
 e. __Certificate Field:__ `subject:givenName` (2.5.4.42) and/or `subject:surname` (2.5.4.4)  
    __Contents:__ If present, the `subject:givenName` field and `subject:surname` field SHALL contain a Natural Person Subject’s name as verified under [Section 3.2.4](#324-authentication-of-individual-identity). Subjects with a single legal name SHALL provide the name in the `subject:surname` attribute. The `subject:givenName` and/or `subject:surname` SHALL NOT be present if the `subject:pseudonym` is present.

--- a/SBR.md
+++ b/SBR.md
@@ -87,7 +87,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.6   | SMC08    |Deprecate Legacy Generation Profiles and Minor Updates | August 29, 2024 |
 | 1.0.7   | SMC09    |Update to WebTrust requirements, require linting, minor edits | November 22, 2024 |
 | 1.0.8   | SMC010   |Introduction of Multi-Perspective Issuance Corroboration | December 22, 2024 |
-| 1.0.9   | SMC011   |Add EUID as Registration Reference | TBD |
+| 1.0.9   | SMC011   |Add EUID as Registration Reference | May 14, 2025 |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 

--- a/SBR.md
+++ b/SBR.md
@@ -2215,7 +2215,7 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
 
     * `NTRGB-12345678` (NTR scheme, Great Britain, Registration Reference at Country level is 12345678).
     * `NTRUS+CA-12345678` (NTR Scheme, United States - California, Registration Reference at State level is 12345678).
-    * `NTRDE+HE-123456789` (NTR Scheme, Germany - Hessen, Registration Reference at State Level is 12345678).
+    * `NTRDE+HE-12345678` (NTR Scheme, Germany - Hessen, Registration Reference at State Level is 12345678).
     * `PSDBE-NBB-1234.567.890` (PSD Scheme, Belgium, NCA's identifier is NBB, Registration Reference assigned by the NCA is 1234.567.890).
 
    Registration Schemes listed in [Appendix A](#appendix-a---registration-schemes) are recognized as valid under these Requirements. The CA SHALL:

--- a/SBR.md
+++ b/SBR.md
@@ -1,9 +1,9 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted S/MIME Certificates
-subtitle: Version 1.0.8
+subtitle: Version TBD
 author:
   - CA/Browser Forum
-date: December 22, 2024
+date: TBD
 copyright: |
   Copyright 2024 CA/Browser Forum
   This work is licensed under the Creative Commons Attribution 4.0 International license.

--- a/SBR.md
+++ b/SBR.md
@@ -2221,7 +2221,7 @@ If the Registration Reference is assigned at the subdivision (state or province)
     * a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8)); and
     * Registration Reference allocated in accordance with the identified Registration Scheme.
 
- Registration References MAY contain hyphens but Registration Schemes, ISO 3166-1 country codes, and ISO 3166-2 identifiers do not. Therefore if more than one hyphen appears in the structure, the leftmost hyphen is a separator, and the remaining hyphens are part of the Registration Reference. For example:
+ Registration References MAY contain hyphens but Registration Schemes, ISO 3166-1 country codes, and ISO 3166-2 identifiers SHALL NOT contain hyphens. Therefore if more than one hyphen appears in the structure, the leftmost hyphen is a separator, and the remaining hyphens are part of the Registration Reference. For example:
 
     * `NTRGB-12345678` (NTR scheme, Great Britain, Registration Reference at Country level is 12345678).
     * `NTRUS+CA-12345678` (NTR Scheme, United States - California, Registration Reference at State level is 12345678).

--- a/SBR.md
+++ b/SBR.md
@@ -2238,14 +2238,14 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
 
    **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the EUID MAY be used as the Registration Reference. In Germany, the EUID SHOULD be used as the Registration Reference. The structure of the EUID SHALL be as follows:
 
-   * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
-   * the register identifier, for the (member state) domestic register;
-   * dot-sign ‘.’ (U+002E); and 
-   * the registration number, asssigned by the domestic register to the Legal Entity.
-   * A check digit SHOULD NOT be used.
+    * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
+    * the register identifier, for the (member state) domestic register;
+    * dot-sign ‘.’ (U+002E); and 
+    * the registration number, asssigned by the domestic register to the Legal Entity.
+    * A check digit SHOULD NOT be used.
   
-  For example:
-   * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the register ID for the local district court in Cologne, and HRB12345 is the locally-assigned registration number for the Legal Entity)
+    For example:
+    * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the register ID for the local district court in Cologne, and HRB12345 is the locally-assigned registration number for the Legal Entity)
 
 e. __Certificate Field:__ `subject:givenName` (2.5.4.42) and/or `subject:surname` (2.5.4.4)  
    __Contents:__ If present, the `subject:givenName` field and `subject:surname` field SHALL contain a Natural Person Subject’s name as verified under [Section 3.2.4](#324-authentication-of-individual-identity). Subjects with a single legal name SHALL provide the name in the `subject:surname` attribute. The `subject:givenName` and/or `subject:surname` SHALL NOT be present if the `subject:pseudonym` is present.

--- a/SBR.md
+++ b/SBR.md
@@ -87,6 +87,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.6   | SMC08    |Deprecate Legacy Generation Profiles and Minor Updates | August 29, 2024 |
 | 1.0.7   | SMC09    |Update to WebTrust requirements, require linting, minor edits | November 22, 2024 |
 | 1.0.8   | SMC010   |Introduction of Multi-Perspective Issuance Corroboration | December 22, 2024 |
+| TBD   | TBD    |Add EUID as Registration Reference | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 

--- a/SBR.md
+++ b/SBR.md
@@ -5,7 +5,7 @@ author:
   - CA/Browser Forum
 date: TBD
 copyright: |
-  Copyright 2024 CA/Browser Forum
+  Copyright 2025 CA/Browser Forum
   This work is licensed under the Creative Commons Attribution 4.0 International license.
 ---
 
@@ -98,7 +98,6 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.3 | SMC05  | SHOULD adoption of CAA for S/MIME | September 15, 2024|
 | 1.0.3 | SMC05  | SHALL adoption of CAA for S/MIME | March 15, 2025|
 | 1.0.4 | SMC06  | Requirement to check Active status of Legal Entity Applicants | September 15, 2024|
-| 1.0.6 | SMC08  | S/MIME Subscriber Certificates SHALL NOT be issued using the Legacy Generation profiles | July 15, 2025 |
 | 1.0.6 | SMC08  | S/MIME Subscriber Certificates SHALL NOT be issued using the Legacy Generation profiles | July 15, 2025 |
 | 1.0.7 | SMC09  | WebTrust audits SHALL include WebTrust for Network Security  | April 1, 2025 |
 | 1.0.7 | SMC09  |SHOULD implement pre-issuance linting of S/MIME Certificates, and SHOULD implement use of Linting in Self-Audits | March 15, 2025 |

--- a/SBR.md
+++ b/SBR.md
@@ -2234,7 +2234,7 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
     * GOVUS+CA (Government Entity, United States - California)
     * INTXG (International Organization)
 
-   **Note 3**: For the NTR Registration Scheme, where the Legal Entity is registered within a European country, the NTR Registration Scheme SHALL be assigned at the country level.
+   **Note 3**: For the NTR Registration Scheme, where the Legal Entity is registered within a Member State of the European Union, the NTR Registration Scheme SHALL be assigned at the country level.
 
    **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the EUID MAY be used as the Registration Reference. In Germany, the EUID SHOULD be used as the Registration Reference. The structure of the EUID SHALL be as follows:
 

--- a/SBR.md
+++ b/SBR.md
@@ -2235,6 +2235,11 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
 
    **Note 3**: For the NTR Registration Scheme, where the Legal Entity is registered within a European country, the NTR Registration Scheme SHALL be assigned at the country level.
 
+   **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in Germany, the European Unique Identifier (EUID) SHOULD be used as Registration Reference. Where it is registered in another country within the European Union or the European Economic Area, the EUID MAY be used as Registration Reference. See [Appendix A.1](#A.1 organizationIdentifier).
+
+   For example:
+   * NTRDE-DER3306.HRB66812 
+
 e. __Certificate Field:__ `subject:givenName` (2.5.4.42) and/or `subject:surname` (2.5.4.4)  
    __Contents:__ If present, the `subject:givenName` field and `subject:surname` field SHALL contain a Natural Person Subject’s name as verified under [Section 3.2.4](#324-authentication-of-individual-identity). Subjects with a single legal name SHALL provide the name in the `subject:surname` attribute. The `subject:givenName` and/or `subject:surname` SHALL NOT be present if the `subject:pseudonym` is present.
 

--- a/SBR.md
+++ b/SBR.md
@@ -2258,7 +2258,7 @@ If the Registration Reference is assigned at the subdivision (state or province)
     * the Registration Reference allocated by the domestic register.
   
     For example:
-    * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the register ID for the district court in Cologne, and HRB12345 is the locally-assigned Registration Reference).
+    * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the business register ID for the district court in Cologne, and HRB12345 is the locally-assigned Registration Reference).
 
 e. __Certificate Field:__ `subject:givenName` (2.5.4.42) and/or `subject:surname` (2.5.4.4)  
    __Contents:__ If present, the `subject:givenName` field and `subject:surname` field SHALL contain a Natural Person Subject’s name as verified under [Section 3.2.4](#324-authentication-of-individual-identity). Subjects with a single legal name SHALL provide the name in the `subject:surname` attribute. The `subject:givenName` and/or `subject:surname` SHALL NOT be present if the `subject:pseudonym` is present.

--- a/SBR.md
+++ b/SBR.md
@@ -2215,7 +2215,7 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
 
     * `NTRGB-12345678` (NTR scheme, Great Britain, Registration Reference at Country level is 12345678).
     * `NTRUS+CA-12345678` (NTR Scheme, United States - California, Registration Reference at State level is 12345678).
-    * `VATDE-123456789` (VAT Scheme, Germany, Registration Reference at Country Level is 12345678).
+    * `NTRDE+HE-123456789` (NTR Scheme, Germany - Hessen, Registration Reference at State Level is 12345678).
     * `PSDBE-NBB-1234.567.890` (PSD Scheme, Belgium, NCA's identifier is NBB, Registration Reference assigned by the NCA is 1234.567.890).
 
    Registration Schemes listed in [Appendix A](#appendix-a---registration-schemes) are recognized as valid under these Requirements. The CA SHALL:

--- a/SBR.md
+++ b/SBR.md
@@ -1,6 +1,6 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted S/MIME Certificates
-subtitle: Version TBD
+subtitle: Version 1.0.9
 author:
   - CA/Browser Forum
 date: TBD

--- a/SBR.md
+++ b/SBR.md
@@ -413,23 +413,23 @@ The Definitions found in the [CA/Browser Forum's Network and Certificate System 
 
 ###  1.6.3 References
 
-ETSI EN 319 403, Electronic Signatures and Infrastructures (ESI); Trust Service Provider Conformity Assessment - Requirements for conformity assessment bodies assessing Trust Service Providers.
+ETSI EN 319 403, Electronic Signatures and Trust Infrastructures (ESI); Trust Service Provider Conformity Assessment - Requirements for conformity assessment bodies assessing Trust Service Providers.
 
-ETSI EN 319 403-1, Electronic Signatures and Infrastructures (ESI); Trust Service Provider Conformity Assessment; Part 1 - Requirements for conformity assessment bodies assessing Trust Service Providers.
+ETSI EN 319 403-1, Electronic Signatures and Trust Infrastructures (ESI); Trust Service Provider Conformity Assessment; Part 1 - Requirements for conformity assessment bodies assessing Trust Service Providers.
 
-ETSI EN 319 411-1, Electronic Signatures and Infrastructures (ESI); Policy and security requirements for Trust Service Providers issuing certificates; Part 1: General requirements.
+ETSI EN 319 411-1, Electronic Signatures and Trust Infrastructures (ESI); Policy and security requirements for Trust Service Providers issuing certificates; Part 1: General requirements.
 
-ETSI EN 319 411-2, Electronic Signatures and Infrastructures (ESI); Policy and security requirements for Trust Service Providers issuing certificates; Part 2: Requirements for trust service providers issuing EU qualified certificates.
+ETSI EN 319 411-2, Electronic Signatures and Trust Infrastructures (ESI); Policy and security requirements for Trust Service Providers issuing certificates; Part 2: Requirements for trust service providers issuing EU qualified certificates.
 
-ETSI EN 119 411-6, Electronic Signatures and Infrastructures (ESI); Policy and security requirements for Trust Service Providers issuing certificates; Part 6: Requirements for Trust Service Providers issuing publicly trusted S/MIME certificates.
+ETSI EN 119 411-6, Electronic Signatures and Trust Infrastructures (ESI); Policy and security requirements for Trust Service Providers issuing certificates; Part 6: Requirements for Trust Service Providers issuing publicly trusted S/MIME certificates.
 
-ETSI EN 319 412-1, Electronic Signatures and Infrastructures (ESI); Certificate Profiles; Part 1: Overview and common data structures.
+ETSI EN 319 412-1, Electronic Signatures and Trust Infrastructures (ESI); Certificate Profiles; Part 1: Overview and common data structures.
 
-ETSI EN 319 412-5, Electronic Signatures and Infrastructures (ESI); Certificate Profiles; Part 5: QCStatements.
+ETSI EN 319 412-5, Electronic Signatures and Trust Infrastructures (ESI); Certificate Profiles; Part 5: QCStatements.
 
-ETSI TS 119 172-4, Electronic Signatures and Infrastructures (ESI); Signature Policies;. Part 4: Signature applicability rules.
+ETSI TS 119 172-4, Electronic Signatures and Trust Infrastructures (ESI); Signature Policies;. Part 4: Signature applicability rules.
 
-ETSI TS 119 495, Electronic Signatures and Infrastructures (ESI); Sector Specific Requirements; Certificate Profiles and TSP Policy Requirements for Open Banking.
+ETSI TS 119 495, Electronic Signatures and Trust Infrastructures (ESI); Sector Specific Requirements; Certificate Profiles and TSP Policy Requirements for Open Banking.
 
 FIPS 140-2, Federal Information Processing Standards Publication - Security Requirements For Cryptographic Modules, Information Technology Laboratory, National Institute of Standards and Technology, May 25, 2001.
 

--- a/SBR.md
+++ b/SBR.md
@@ -2249,7 +2249,7 @@ If the Registration Reference is assigned at the subdivision (state or province)
     * GOVUS+CA (Government Entity, United States - California)
     * INTXG (International Organization)
 
-   **Note 3**: For the NTR Registration Scheme, when the Organization or Legal Entity is registered in the European Union or the European Economic Area, the Registration Reference MAY be use the EUID identifier. When the Organization or Legal Entity is registered in Germany, the Registration Reference SHOULD use the EUID identifier. The structure of the EUID SHALL be as follows:
+   **Note 3**: For the NTR Registration Scheme, when the Organization or Legal Entity is registered in the European Union or the European Economic Area, the Registration Reference MAY use the EUID identifier. When the Organization or Legal Entity is registered in Germany, the Registration Reference SHOULD use the EUID identifier. The structure of the EUID SHALL be as follows:
 
     * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR'; and
     * the business register identifier for the particular section or office of the domestic register that assigned the Registration Reference; and

--- a/SBR.md
+++ b/SBR.md
@@ -2210,13 +2210,14 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
     * 3 character Registration Scheme identifier;
     * 2 character ISO 3166-1 country code for the nation in which the Registration Scheme is operated, or as described in Note 1; and
     * a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8)); and
-    * Registration Reference allocated in accordance with the identified Registration Scheme.
+    * Registration Reference allocated in accordance with the identified Registration Scheme (or as described in Note 3).
 
 If the Registration Reference is assigned at the subdivision (state or province) level and is not unique at the national level, the Registration Scheme SHALL be identified using the following structure in the presented order:
 
     * 3 character Registration Scheme identifier;
     * 2 character ISO 3166-1 country code for the nation in which the Registration Scheme is operated; and
-    * plus "+" (0x2B (ASCII), U+002B (UTF-8)) followed by an up-to-three character ISO 3166-2 identifier for the subdivision; and
+    * plus "+" (0x2B (ASCII), U+002B (UTF-8)); and 
+    * up-to-3 character ISO 3166-2 identifier for the subdivision; and
     * a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8)); and
     * Registration Reference allocated in accordance with the identified Registration Scheme.
 
@@ -2245,12 +2246,12 @@ If the Registration Reference is assigned at the subdivision (state or province)
     * GOVUS+CA (Government Entity, United States - California)
     * INTXG (International Organization)
 
-   **Note 3**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the Registration Reference MAY be use the EUID identifier as available from the Business Registers Interconnection System according to Implementing Regulation (EU) 2021/1042. The structure of the EUID SHALL be as follows:
+   **Note 3**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the Registration Reference MAY be use the EUID identifier. The structure of the EUID SHALL be as follows:
 
     * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
     * the business register identifier for the particular section or office of the domestic register that assigned the Registration Reference;
     * dot-sign ‘.’ (U+002E); and 
-    * the Registration Reference, assigned by the domestic register to the Legal Entity.
+    * the Registration Reference allocated by the domestic register.
   
     For example:
     * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the register ID for the district court in Cologne, and HRB12345 is the locally-assigned Registration Reference).

--- a/SBR.md
+++ b/SBR.md
@@ -2199,30 +2199,42 @@ c. __Certificate Field:__ `subject:organizationalUnitName` (OID: 2.5.4.11)
    __Contents:__ If present, the CA SHALL confirm that the `subject:organizationalUnitName` is the full legal organization name of an Affiliate of the `subject:organizationName` in the Certificate and has been verified in accordance with the requirements of [Section 3.2.3](#323-authentication-of-organization-identity). The CA MAY include information in this field that differs slightly from the verified name, such as common variations or abbreviations, provided that the CA documents the difference and any abbreviations used are locally accepted abbreviations.
 
 d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)  
-   __Contents:__ If present, the `subject:organizationIdentifier` field SHALL contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme. The Registration Reference SHOULD be unique where the Registration Scheme and jurisdiction provide unique identifiers. 
+   __Contents:__ If present, the `subject:organizationIdentifier` field SHALL contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme. 
 
    The `subject:organizationIdentifier` SHALL be encoded as a PrintableString or UTF8String.
 
-   The Registration Scheme identified in the Certificate SHALL be the result of the verification performed in accordance with [Section 3.2.3](#323-authentication-of-organization-identity). The Registration Scheme SHALL be identified using the following structure in the presented order:
+   The Registration Scheme identified in the Certificate SHALL be the result of the verification performed in accordance with [Section 3.2.3](#323-authentication-of-organization-identity). 
+   
+   If the Registration Reference is assigned at the country level, the Registration Scheme SHALL be identified using the following structure in the presented order:
 
     * 3 character Registration Scheme identifier;
-    * 2 character ISO 3166-1 country code for the nation in which the Registration Scheme is operated, or if the scheme is operated globally (such as LEI) then the ISO 3166-1 code "XG" SHALL be used;
-    * For the NTR Registration Scheme identifier, where registrations are administrated at the subdivision (state or province) level, a plus "+" (0x2B (ASCII), U+002B (UTF-8)) followed by an up-to-three alphanumeric character ISO 3166-2 identifier for the subdivision of the nation in which the Registration Scheme is operated;
-    * a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8));
+    * 2 character ISO 3166-1 country code for the nation in which the Registration Scheme is operated, or as described in Note 1; and
+    * a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8)); and
     * Registration Reference allocated in accordance with the identified Registration Scheme.
 
-   **Note 1**: Registration References MAY contain hyphens but Registration Schemes, ISO 3166-1 country codes, and ISO 3166-2 identifiers do not. Therefore if more than one hyphen appears in the structure, the leftmost hyphen is a separator, and the remaining hyphens are part of the Registration Reference. For example:
+If the Registration Reference is assigned at the subdivision (state or province) level and is not unique at the national level, the Registration Scheme SHALL be identified using the following structure in the presented order:
+
+    * 3 character Registration Scheme identifier;
+    * 2 character ISO 3166-1 country code for the nation in which the Registration Scheme is operated; and
+    * plus "+" (0x2B (ASCII), U+002B (UTF-8)) followed by an up-to-three character ISO 3166-2 identifier for the subdivision; and
+    * a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8)); and
+    * Registration Reference allocated in accordance with the identified Registration Scheme.
+
+ Registration References MAY contain hyphens but Registration Schemes, ISO 3166-1 country codes, and ISO 3166-2 identifiers do not. Therefore if more than one hyphen appears in the structure, the leftmost hyphen is a separator, and the remaining hyphens are part of the Registration Reference. For example:
 
     * `NTRGB-12345678` (NTR scheme, Great Britain, Registration Reference at Country level is 12345678).
     * `NTRUS+CA-12345678` (NTR Scheme, United States - California, Registration Reference at State level is 12345678).
     * `NTRDE+HE-12345678` (NTR Scheme, Germany - Hessen, Registration Reference at State Level is 12345678).
     * `PSDBE-NBB-1234.567.890` (PSD Scheme, Belgium, NCA's identifier is NBB, Registration Reference assigned by the NCA is 1234.567.890).
+    * `VATEL-123456789` (VAT Scheme, Greece using EU Council Directive 2006/112/EC as amended, Registration Reference is 12345678).
 
    Registration Schemes listed in [Appendix A](#appendix-a---registration-schemes) are recognized as valid under these Requirements. The CA SHALL:
 
    1. Confirm that the organization represented by the Registration Reference is the same as the organization named in the `organizationName` field as specified in [Section 7.1.4.2.2](#71422-subject-distinguished-name-fields); and
    2. Further verify the Registration Reference matches other information verified in accordance with [Section 3.2.3](#323-authentication-of-organization-identity).
-
+   
+   **Note 1**: If a Registration Scheme is operated globally (such as LEI) then the ISO 3166-1 code "XG" SHALL be used. For the VAT Registration Scheme, the country prefix described in Article 215 of EU Council Directive 2006/112/EC, as amended, MAY be used instead of the ISO 3166-1 country code. 
+   
    **Note 2**: For the following types of entities that do not have an identifier from the Registration Schemes listed in [Appendix A](#appendix-a---registration-schemes):
 
     * For Government Entities, the CA SHALL enter the Registration Scheme identifier ‘GOV’ followed by the 2 character ISO 3166-1 country code for the nation in which the Government Entity is located.  If the Government Entity is verified at a subdivision (state or province) level, then a plus "+" (0x2B (ASCII), U+002B (UTF-8)) followed by an ISO 3166-2 identifier for the subdivision (up to three alphanumeric characters) is added.
@@ -2233,18 +2245,15 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
     * GOVUS+CA (Government Entity, United States - California)
     * INTXG (International Organization)
 
-   **Note 3**: For the NTR Registration Scheme, where the Legal Entity is registered within a Member State of the European Union, the NTR Registration Scheme SHALL be assigned at the country level.
-
-   **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the EUID MAY be used as the Registration Reference. In Germany, the EUID SHOULD be used as the Registration Reference. The structure of the EUID SHALL be as follows:
+   **Note 3**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the Registration Reference MAY be use the EUID identifier as available from the Business Registers Interconnection System according to Implementing Regulation (EU) 2021/1042. The structure of the EUID SHALL be as follows:
 
     * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
-    * the register identifier, for the (member state) domestic register;
+    * the business register identifier for the particular section or office of the domestic register that assigned the Registration Reference;
     * dot-sign ‘.’ (U+002E); and 
-    * the registration number, assigned by the domestic register to the Legal Entity.
-    * A check digit SHOULD NOT be used.
+    * the Registration Reference, assigned by the domestic register to the Legal Entity.
   
     For example:
-    * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the register ID for the local district court in Cologne, and HRB12345 is the locally-assigned registration number for the Legal Entity)
+    * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the register ID for the district court in Cologne, and HRB12345 is the locally-assigned Registration Reference).
 
 e. __Certificate Field:__ `subject:givenName` (2.5.4.42) and/or `subject:surname` (2.5.4.4)  
    __Contents:__ If present, the `subject:givenName` field and `subject:surname` field SHALL contain a Natural Person Subject’s name as verified under [Section 3.2.4](#324-authentication-of-individual-identity). Subjects with a single legal name SHALL provide the name in the `subject:surname` attribute. The `subject:givenName` and/or `subject:surname` SHALL NOT be present if the `subject:pseudonym` is present.

--- a/SBR.md
+++ b/SBR.md
@@ -2235,10 +2235,10 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
 
    **Note 3**: For the NTR Registration Scheme, where the Legal Entity is registered within a European country, the NTR Registration Scheme SHALL be assigned at the country level.
 
-   **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in Germany, the European Unique Identifier (EUID) SHOULD be used as Registration Reference. Where it is registered in another country within the European Union or the European Economic Area, the EUID MAY be used as Registration Reference. See [Appendix A.1](#A.1 organizationIdentifier).
+   **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the EUID MAY be used as the Registration Reference. In Germany, the EUID SHOULD be used as the Registration Reference. See [Appendix A.1](#a1-organizationidentifier).
 
    For example:
-   * NTRDE-DER3306.HRB66812 
+   * NTRDE-DER3306.HRB66812 where DE is the country code for Germany, R3306 the register ID for the local district court Cologne and HRB66812 the locally-assigned register number for the Legal Entity.
 
 e. __Certificate Field:__ `subject:givenName` (2.5.4.42) and/or `subject:surname` (2.5.4.4)  
    __Contents:__ If present, the `subject:givenName` field and `subject:surname` field SHALL contain a Natural Person Subject’s name as verified under [Section 3.2.4](#324-authentication-of-individual-identity). Subjects with a single legal name SHALL provide the name in the `subject:surname` attribute. The `subject:givenName` and/or `subject:surname` SHALL NOT be present if the `subject:pseudonym` is present.
@@ -2851,6 +2851,16 @@ For the VAT Registration Scheme, for the purpose of identifying tax authorities,
 * **PSD**: For a national authorization number allocated to the payment service provider named in the `subject:organizationName` under Payments Services Directive (EU) 2015/2366. This shall use the extended structure as defined in ETSI TS 119 495, clause 5.2.1. 
 
 * **LEI**: For a Legal Entity Identifier as specified in ISO 17442 for the entity named in the `subject:organizationName`. The 2 character ISO 3166-1 country code SHALL be set to 'XG'. 
+
+### European Unique Identifier (EUID)
+
+For the NTR Registration Scheme used with a European Unique Identifier (EUID) as the Registration Reference according to the Implementing Regulation (EU) 2021/1042, the structure of the EUID SHALL be as follows:
+
+* 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
+* the register identifier, for the (member state) domestic register;
+* dot-sign ‘.’ (U+002E);
+* the registration number, asssigned by the domestic register to the Legal Entity.
+* A check digit SHOULD NOT be used.
 
 ## A.2 Natural Person Identifier
 

--- a/SBR.md
+++ b/SBR.md
@@ -2234,7 +2234,11 @@ If the Registration Reference is assigned at the subdivision (state or province)
    1. Confirm that the organization represented by the Registration Reference is the same as the organization named in the `organizationName` field as specified in [Section 7.1.4.2.2](#71422-subject-distinguished-name-fields); and
    2. Further verify the Registration Reference matches other information verified in accordance with [Section 3.2.3](#323-authentication-of-organization-identity).
    
-   **Note 1**: If a Registration Scheme is operated globally (such as LEI) then the ISO 3166-1 code "XG" SHALL be used. For the VAT Registration Scheme, the country prefix described in Article 215 of EU Council Directive 2006/112/EC, as amended, MAY be used instead of the ISO 3166-1 country code. 
+   **Note 1**: With the exception of the LEI and INT Registration Schemes, if a `subject:countryName` is present in the Certificate the country code used in the Registration Scheme identifier SHALL match that of the `subject:countryName` in the Certificate. 
+
+   For the VAT Registration Scheme, the country prefix described in Article 215 of EU Council Directive 2006/112/EC, as amended, MAY be used instead of the ISO 3166-1 country code. If the country prefix described in Article 215 of EU Council Directive 2006/112/EC is used, the `subject:countryName` attribute, if present, SHALL contain the corresponding ISO 3166-1 country code.
+   
+   For the LEI Registration Scheme, the ISO 3166-1 code "XG" SHALL be used. 
    
    **Note 2**: For the following types of entities that do not have an identifier from the Registration Schemes listed in [Appendix A](#appendix-a---registration-schemes):
 
@@ -2855,12 +2859,6 @@ No stipulation.
 ## A.1 organizationIdentifier
 
 The following Registration Schemes are recognized as valid under these Requirements for use in the `subject:organizationIdentifier` attribute described in [Section 7.1.4.2.2](#71422-subject-distinguished-name-fields), in addition to the GOV and INT identifiers described therein.
-
-With the exception of the LEI and INT Registration Schemes, as specified in [Section 7.1.4.2.2](#71422-subject-distinguished-name-fields), if a `subject:countryName` is present in the Certificate the country code used in the Registration Scheme identifier SHALL match that of the `subject:countryName` in the Certificate. 
-
-For the VAT Registration Scheme, for the purpose of identifying tax authorities, the country prefix described in Article 215 of EU Council Directive 2006/112/EC, as amended, MAY be used instead of the ISO 3166-1 country code. If the country prefix described in Article 215 of EU Council Directive 2006/112/EC is used, the `subject:countryName` attribute, if present, SHALL contain the corresponding ISO 3166-1 country code.
-
-For the NTR Registration Scheme, the European Unique Identifier (EUID) MAY be used as the Registration Reference as specified in [Section 7.1.4.2.2](#71422-subject-distinguished-name-fields).
 
 * **NTR**: For an identifier allocated by a national or state trade register to the Legal Entity named in the `subject:organizationName`. 
 

--- a/SBR.md
+++ b/SBR.md
@@ -2240,7 +2240,7 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
     * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
     * the register identifier, for the (member state) domestic register;
     * dot-sign ‘.’ (U+002E); and 
-    * the registration number, asssigned by the domestic register to the Legal Entity.
+    * the registration number, assigned by the domestic register to the Legal Entity.
     * A check digit SHOULD NOT be used.
   
     For example:

--- a/SBR.md
+++ b/SBR.md
@@ -2207,14 +2207,14 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
    
    If the Registration Reference is assigned at the country level, the Registration Scheme SHALL be identified using the following structure in the presented order:
 
-    * 3 character Registration Scheme identifier;
+    * 3 character Registration Scheme identifier; and
     * 2 character ISO 3166-1 country code for the nation in which the Registration Scheme is operated, or as described in Note 1; and
     * a hyphen-minus "-" (0x2D (ASCII), U+002D (UTF-8)); and
     * Registration Reference allocated in accordance with the identified Registration Scheme (or as described in Note 3).
 
 If the Registration Reference is assigned at the subdivision (state or province) level and is not unique at the national level, the Registration Scheme SHALL be identified using the following structure in the presented order:
 
-    * 3 character Registration Scheme identifier;
+    * 3 character Registration Scheme identifier; and
     * 2 character ISO 3166-1 country code for the nation in which the Registration Scheme is operated; and
     * plus "+" (0x2B (ASCII), U+002B (UTF-8)); and 
     * up-to-3 character ISO 3166-2 identifier for the subdivision; and
@@ -2226,7 +2226,7 @@ If the Registration Reference is assigned at the subdivision (state or province)
     * `NTRGB-12345678` (NTR scheme, Great Britain, Registration Reference at Country level is 12345678).
     * `NTRUS+CA-12345678` (NTR Scheme, United States - California, Registration Reference at State level is 12345678).
     * `NTRDE+HE-12345678` (NTR Scheme, Germany - Hessen, Registration Reference at State Level is 12345678).
-    * `PSDBE-NBB-1234.567.890` (PSD Scheme, Belgium, NCA's identifier is NBB, Registration Reference assigned by the NCA is 1234.567.890).
+    * `PSDBE-NBB-1234.567.890` (PSD Scheme, Belgium, National Competent Authority identifier is NBB, Registration Reference assigned by the NCA is 1234.567.890).
     * `VATEL-123456789` (VAT Scheme, Greece using EU Council Directive 2006/112/EC as amended, Registration Reference is 12345678).
 
    Registration Schemes listed in [Appendix A](#appendix-a---registration-schemes) are recognized as valid under these Requirements. The CA SHALL:
@@ -2252,8 +2252,8 @@ If the Registration Reference is assigned at the subdivision (state or province)
 
    **Note 3**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the Registration Reference MAY be use the EUID identifier. The structure of the EUID SHALL be as follows:
 
-    * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
-    * the business register identifier for the particular section or office of the domestic register that assigned the Registration Reference;
+    * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR'; and
+    * the business register identifier for the particular section or office of the domestic register that assigned the Registration Reference; and
     * dot-sign ‘.’ (U+002E); and 
     * the Registration Reference allocated by the domestic register.
   

--- a/SBR.md
+++ b/SBR.md
@@ -2199,7 +2199,7 @@ c. __Certificate Field:__ `subject:organizationalUnitName` (OID: 2.5.4.11)
    __Contents:__ If present, the CA SHALL confirm that the `subject:organizationalUnitName` is the full legal organization name of an Affiliate of the `subject:organizationName` in the Certificate and has been verified in accordance with the requirements of [Section 3.2.3](#323-authentication-of-organization-identity). The CA MAY include information in this field that differs slightly from the verified name, such as common variations or abbreviations, provided that the CA documents the difference and any abbreviations used are locally accepted abbreviations.
 
 d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)  
-   __Contents:__ If present, the `subject:organizationIdentifier` field SHALL contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme. 
+   __Contents:__ If present, the `subject:organizationIdentifier` field SHALL contain a Registration Reference for a Legal Entity assigned in accordance to the identified Registration Scheme. The Registration Reference SHOULD be unique where the Registration Scheme and jurisdiction provide unique identifiers.
 
    The `subject:organizationIdentifier` SHALL be encoded as a PrintableString or UTF8String.
 
@@ -2225,7 +2225,6 @@ If the Registration Reference is assigned at the subdivision (state or province)
 
     * `NTRGB-12345678` (NTR scheme, Great Britain, Registration Reference at Country level is 12345678).
     * `NTRUS+CA-12345678` (NTR Scheme, United States - California, Registration Reference at State level is 12345678).
-    * `NTRDE+HE-12345678` (NTR Scheme, Germany - Hessen, Registration Reference at State Level is 12345678).
     * `PSDBE-NBB-1234.567.890` (PSD Scheme, Belgium, National Competent Authority identifier is NBB, Registration Reference assigned by the NCA is 1234.567.890).
     * `VATEL-123456789` (VAT Scheme, Greece using EU Council Directive 2006/112/EC as amended, Registration Reference is 12345678).
 
@@ -2250,7 +2249,7 @@ If the Registration Reference is assigned at the subdivision (state or province)
     * GOVUS+CA (Government Entity, United States - California)
     * INTXG (International Organization)
 
-   **Note 3**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the Registration Reference MAY be use the EUID identifier. The structure of the EUID SHALL be as follows:
+   **Note 3**: For the NTR Registration Scheme, when the Organization or Legal Entity is registered in the European Union or the European Economic Area, the Registration Reference MAY be use the EUID identifier. When the Organization or Legal Entity is registered in Germany, the Registration Reference SHOULD use the EUID identifier. The structure of the EUID SHALL be as follows:
 
     * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR'; and
     * the business register identifier for the particular section or office of the domestic register that assigned the Registration Reference; and

--- a/SBR.md
+++ b/SBR.md
@@ -3,7 +3,7 @@ title: Baseline Requirements for the Issuance and Management of Publicly-Trusted
 subtitle: Version 1.0.9
 author:
   - CA/Browser Forum
-date: TBD
+date: May 14, 2025
 copyright: |
   Copyright 2025 CA/Browser Forum
   This work is licensed under the Creative Commons Attribution 4.0 International license.

--- a/SBR.md
+++ b/SBR.md
@@ -2236,10 +2236,16 @@ d. __Certificate Field:__ `subject:organizationIdentifier` (2.5.4.97)
 
    **Note 3**: For the NTR Registration Scheme, where the Legal Entity is registered within a European country, the NTR Registration Scheme SHALL be assigned at the country level.
 
-   **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the EUID MAY be used as the Registration Reference. In Germany, the EUID SHOULD be used as the Registration Reference. See [Appendix A.1](#a1-organizationidentifier).
+   **Note 4**: For the NTR Registration Scheme, where the Organization or Legal Entity is registered in the European Union or the European Economic Area, the EUID MAY be used as the Registration Reference. In Germany, the EUID SHOULD be used as the Registration Reference. See [Appendix A.1](#a1-organizationidentifier).The structure of the EUID SHALL be as follows:
 
-   For example:
-   * NTRDE-DER3306.HRB66812 where DE is the country code for Germany, R3306 the register ID for the local district court Cologne and HRB66812 the locally-assigned register number for the Legal Entity.
+   * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
+   * the register identifier, for the (member state) domestic register;
+   * dot-sign ‘.’ (U+002E); and 
+   * the registration number, asssigned by the domestic register to the Legal Entity.
+   * A check digit SHOULD NOT be used.
+  
+  For example:
+   * NTRDE-DER3306.HRB12345 (DE is the country code for Germany, R3306 is the register ID for the local district court in Cologne, and HRB12345 is the locally-assigned registration number for the Legal Entity)
 
 e. __Certificate Field:__ `subject:givenName` (2.5.4.42) and/or `subject:surname` (2.5.4.4)  
    __Contents:__ If present, the `subject:givenName` field and `subject:surname` field SHALL contain a Natural Person Subject’s name as verified under [Section 3.2.4](#324-authentication-of-individual-identity). Subjects with a single legal name SHALL provide the name in the `subject:surname` attribute. The `subject:givenName` and/or `subject:surname` SHALL NOT be present if the `subject:pseudonym` is present.

--- a/SBR.md
+++ b/SBR.md
@@ -87,7 +87,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.6   | SMC08    |Deprecate Legacy Generation Profiles and Minor Updates | August 29, 2024 |
 | 1.0.7   | SMC09    |Update to WebTrust requirements, require linting, minor edits | November 22, 2024 |
 | 1.0.8   | SMC010   |Introduction of Multi-Perspective Issuance Corroboration | December 22, 2024 |
-| TBD   | TBD    |Add EUID as Registration Reference | TBD |
+| 1.0.9   | SMC011   |Add EUID as Registration Reference | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 
@@ -427,9 +427,9 @@ ETSI EN 319 412-1, Electronic Signatures and Infrastructures (ESI); Certificate 
 
 ETSI EN 319 412-5, Electronic Signatures and Infrastructures (ESI); Certificate Profiles; Part 5: QCStatements.
 
-ETSI TS 119 495, Electronic Signatures and Infrastructures (ESI); Sector Specific Requirements; Certificate Profiles and TSP Policy Requirements for Open Banking.
-
 ETSI TS 119 172-4, Electronic Signatures and Infrastructures (ESI); Signature Policies;. Part 4: Signature applicability rules.
+
+ETSI TS 119 495, Electronic Signatures and Infrastructures (ESI); Sector Specific Requirements; Certificate Profiles and TSP Policy Requirements for Open Banking.
 
 FIPS 140-2, Federal Information Processing Standards Publication - Security Requirements For Cryptographic Modules, Information Technology Laboratory, National Institute of Standards and Technology, May 25, 2001.
 
@@ -463,11 +463,11 @@ RFC 6818, Updates to the Internet X.509 Public Key Infrastructure Certificate an
 
 RFC 6960, Request for Comments: 6960, X.509 Internet Public Key Infrastructure Online Certificate Status Protocol - OCSP. S. Santesson, et al. June 2013.
 
-RFC 9598, Request for Comments: 9598, Internationalized Email Addresses in X.509 Certificates, A. Melnikov, et al. May 2024.
-
 RFC 8499, Request for Comments: 8499, DNS Terminology. P. Hoffman, et al. January 2019.
 
 RFC 9495, Request for Comments: 9495, Certification Authority Authorization (CAA) Processing for Email Addresses, C. Bonnell. October 2023.
+
+RFC 9598, Request for Comments: 9598, Internationalized Email Addresses in X.509 Certificates, A. Melnikov, et al. May 2024.
 
 "TLS Baseline Requirements" means the current version of the CA/Browser Forum's "Baseline Requirements for the Issuance and Management of Publicly‐Trusted TLS Server Certificates". See https://cabforum.org/baseline-requirements-documents/
 

--- a/SBR.md
+++ b/SBR.md
@@ -251,6 +251,8 @@ The Definitions found in the [CA/Browser Forum's Network and Certificate System 
 
 **Enterprise RA**: An employee or agent of an organization unaffiliated with the CA who authorizes issuance of Certificates to that organization.
 
+**European Unique Identifier (EUID)**: The EUID uniquely identifies officially registered organizations, Legal Entities, and branch offices within the European Union or the European Economic Area. The EUID is specified in chapter 9 of the Annex contained in the Implementing Regulation (EU) 2021/1042 laying down rules for the application of Directive (EU) 2017/1132 "relating to certain aspects of company law (codification)".
+
 **Expiry Date**: The "Not After" date in a Certificate that defines the end of a Certificate's validity period.
 
 **Extant S/MIME CA**: A Subordinate CA that:

--- a/SBR.md
+++ b/SBR.md
@@ -252,7 +252,7 @@ The Definitions found in the [CA/Browser Forum's Network and Certificate System 
 
 **Enterprise RA**: An employee or agent of an organization unaffiliated with the CA who authorizes issuance of Certificates to that organization.
 
-**European Unique Identifier (EUID)**: The EUID uniquely identifies officially registered organizations, Legal Entities, and branch offices within the European Union or the European Economic Area. The EUID is specified in chapter 9 of the Annex contained in the Implementing Regulation (EU) 2021/1042 laying down rules for the application of Directive (EU) 2017/1132 "relating to certain aspects of company law (codification)".
+**European Unique Identifier (EUID)**: The EUID uniquely identifies officially-registered organizations, Legal Entities, and branch offices within the European Union or the European Economic Area. The EUID is specified in chapter 9 of the Annex contained in the Implementing Regulation (EU) 2021/1042 which describes rules for the application of Directive (EU) 2017/1132 "relating to certain aspects of company law (codification)".
 
 **Expiry Date**: The "Not After" date in a Certificate that defines the end of a Certificate's validity period.
 

--- a/SBR.md
+++ b/SBR.md
@@ -2851,6 +2851,8 @@ With the exception of the LEI and INT Registration Schemes, as specified in [Sec
 
 For the VAT Registration Scheme, for the purpose of identifying tax authorities, the country prefix described in Article 215 of EU Council Directive 2006/112/EC, as amended, MAY be used instead of the ISO 3166-1 country code. If the country prefix described in Article 215 of EU Council Directive 2006/112/EC is used, the `subject:countryName` attribute, if present, SHALL contain the corresponding ISO 3166-1 country code.
 
+For the NTR Registration Scheme, the European Unique Identifier (EUID) MAY be used as the Registration Reference as specified in [Section 7.1.4.2.2](#71422-subject-distinguished-name-fields).
+
 * **NTR**: For an identifier allocated by a national or state trade register to the Legal Entity named in the `subject:organizationName`. 
 
 * **VAT**: For an identifier allocated by the national tax authorities to the Legal Entity named in the `subject:organizationName`. 
@@ -2858,16 +2860,6 @@ For the VAT Registration Scheme, for the purpose of identifying tax authorities,
 * **PSD**: For a national authorization number allocated to the payment service provider named in the `subject:organizationName` under Payments Services Directive (EU) 2015/2366. This shall use the extended structure as defined in ETSI TS 119 495, clause 5.2.1. 
 
 * **LEI**: For a Legal Entity Identifier as specified in ISO 17442 for the entity named in the `subject:organizationName`. The 2 character ISO 3166-1 country code SHALL be set to 'XG'. 
-
-### European Unique Identifier (EUID)
-
-For the NTR Registration Scheme used with a European Unique Identifier (EUID) as the Registration Reference according to the Implementing Regulation (EU) 2021/1042, the structure of the EUID SHALL be as follows:
-
-* 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
-* the register identifier, for the (member state) domestic register;
-* dot-sign ‘.’ (U+002E); and 
-* the registration number, asssigned by the domestic register to the Legal Entity.
-* A check digit SHOULD NOT be used.
 
 ## A.2 Natural Person Identifier
 

--- a/SBR.md
+++ b/SBR.md
@@ -2858,7 +2858,7 @@ For the NTR Registration Scheme used with a European Unique Identifier (EUID) as
 
 * 2 character ISO 3166-1 country code, which must match the country code used in the leading string 'NTR';
 * the register identifier, for the (member state) domestic register;
-* dot-sign ‘.’ (U+002E);
+* dot-sign ‘.’ (U+002E); and 
 * the registration number, asssigned by the domestic register to the Legal Entity.
 * A check digit SHOULD NOT be used.
 


### PR DESCRIPTION
This ballot allows the option to use a European Unique Identifier (EUID) as a Registration Reference in the NTR Registration Scheme.
The EUID uniquely identifies officially-registered organizations, Legal Entities, and branch offices within the European Union or the European Economic Area. The EUID is specified in chapter 9 of the Annex contained in the Implementing Regulation (EU) 2021/1042 which describes rules for the application of Directive (EU) 2017/1132 "relating to certain aspects of company law (codification)".
The ballot also includes several editorial corrections, (e.g., reordering of References and regrouping of information from Appendix A to Section 7.1.4.2.2 (d)).
This ballot is proposed by Stephen Davidson (DigiCert) and endorsed by Adrian Mueller (SwissSign) and Adriano Santoni (Actalis).
