### PR TITLE
Make rfc8410_oids.py more pythonic

### DIFF
--- a/src/rfc8410_oids.py
+++ b/src/rfc8410_oids.py
@@ -1,20 +1,63 @@
-import binascii
+#!/usr/bin/env python3
+"""
+Script to create and print DER-encoded AlgorithmIdentifier structures
+for Ed25519 and Ed448 algorithms.
+"""
+from typing import List
 
 from pyasn1.codec.der.encoder import encode
+from pyasn1.type import univ
 from pyasn1_alt_modules import rfc8410, rfc5280
 
 
-def print_hexstr_algid_for_oid(oid):
-	algid = rfc5280.AlgorithmIdentifier()
-	algid['algorithm'] = oid
+def get_algid_der_hex(oid: univ.ObjectIdentifier) -> str:
+    """
+    Creates an AlgorithmIdentifier for the given OID and returns its
+    DER encoding as a hex string.
 
-	print(algid.prettyPrint())
+    Args:
+        oid: The Object Identifier for the algorithm.
 
-	encoded = encode(algid)
+    Returns:
+        Hexadecimal string of the DER encoded AlgorithmIdentifier.
+    """
+    algid = rfc5280.AlgorithmIdentifier()
+    algid['algorithm'] = oid
+    # Parameters are absent for Ed25519 and Ed448 (RFC 8410)
 
-	print(binascii.b2a_hex(encoded).decode('us-ascii'))
-	print('=' * 50)
+    encoded = encode(algid)
+    return encoded.hex()
 
 
-print_hexstr_algid_for_oid(rfc8410.id_Ed25519)
-print_hexstr_algid_for_oid(rfc8410.id_Ed448)
+def print_algid_info(oid: univ.ObjectIdentifier) -> None:
+    """
+    Prints the pretty representation and DER hex string of the
+    AlgorithmIdentifier for the given OID.
+    """
+    # Create a temporary object just for pretty printing to match original behavior
+    algid = rfc5280.AlgorithmIdentifier()
+    algid['algorithm'] = oid
+
+    print(algid.prettyPrint())
+
+    hex_str = get_algid_der_hex(oid)
+    print(hex_str)
+    print('=' * 50)
+
+
+def main() -> None:
+    """
+    Main execution function.
+    """
+    # List of OIDs to process
+    oids: List[univ.ObjectIdentifier] = [
+        rfc8410.id_Ed25519,
+        rfc8410.id_Ed448,
+    ]
+
+    for oid in oids:
+        print_algid_info(oid)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Refactor the script to create and print DER-encoded AlgorithmIdentifiers. Add functions for encoding and printing hex representation.