### PR TITLE
Ballot SMC016: Equivalence with Ballots SC096 and SC097

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -2092,6 +2092,10 @@ The CA SHALL NOT use a different algorithm, such as the id-RSASSA-PSS (OID: 1.2.
 
 When encoded, the `AlgorithmIdentifier` for RSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes: `300d06092a864886f70d0101010500`
 
+Effective 2026-09-15, the CA MUST NOT use the following signature algorithm and encoding: RSASSA-PKCS1-v1_5 with SHA-1
+
+Prior to 2026‐09‐15, the CA SHALL revoke any unexpired Subordinate CA Certificate that contains `RSASSA-PKCS1-v1_5 with SHA-1` within the Certificate.
+
 ##### 7.1.3.1.2 ECDSA
 
 The CA SHALL indicate an ECDSA key using the id-ecPublicKey (OID: 1.2.840.10045.2.1) algorithm identifier. The parameters SHALL use the `namedCurve` encoding.
@@ -3000,4 +3004,4 @@ Following the Effective Date for v 1.0.0 of these Requirements (September 1, 202
 
 On or after September 15, 2024, all newly-issued Publicly-Trusted end entity S/MIME Certificates SHALL be issued from S/MIME Subordinate CAs that are compliant with these Requirements.
 
-For backwards compatibility, Extant S/MIME CA Certificates that share the same Public Keys with S/MIME Subordinate CAs that are compliant with these Requirements, or are no longer used for signing end entity S/MIME Certificates, are not required to be revoked.
+For backwards compatibility, Extant S/MIME CA Certificates that share the same Public Keys with S/MIME Subordinate CAs that are compliant with these Requirements, or are no longer used for signing end entity S/MIME Certificates, are not required to be revoked, with the exeption of the required revocation of any Certificate contains containing `RSASSA-PKCS1-v1_5 with SHA-1` as per [Section 7.1.3.1.1](#71311-rsa).

--- a/SBR.md
+++ b/SBR.md
@@ -91,7 +91,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC014   |DNSSEC for CAA | October 13, 2025 |
-| 1.0.14  | SMC016   |Ballots SC096 and SC097 | TBD |
+| 1.0.14  | SMC016   |Equivalence with Ballots SC096 and SC097 | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 

--- a/SBR.md
+++ b/SBR.md
@@ -109,6 +109,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
+| 1.0.14 | SMC016 | SHALL all remaining use of SHA-1 in Certificates and CRLs | September 15, 2026 |
 
 ## 1.3 PKI participants
 
@@ -2095,9 +2096,9 @@ The CA SHALL NOT use a different algorithm, such as the id-RSASSA-PSS (OID: 1.2.
 
 When encoded, the `AlgorithmIdentifier` for RSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes: `300d06092a864886f70d0101010500`
 
-Effective 2026-09-15, the CA MUST NOT use the following signature algorithm and encoding: RSASSA-PKCS1-v1_5 with SHA-1
+Effective September 15, 2026 the CA MUST NOT use the following signature algorithm and encoding: RSASSA-PKCS1-v1_5 with SHA-1
 
-Prior to 2026‐09‐15, the CA SHALL revoke any unexpired Subordinate CA Certificate that contains `RSASSA-PKCS1-v1_5 with SHA-1` within the Certificate.
+Prior to September 15, 2026 the CA SHALL revoke any unexpired Subordinate CA Certificate that contains `RSASSA-PKCS1-v1_5 with SHA-1` within the Certificate.
 
 ##### 7.1.3.1.2 ECDSA
 

--- a/SBR.md
+++ b/SBR.md
@@ -3006,4 +3006,4 @@ Following the Effective Date for v 1.0.0 of these Requirements (September 1, 202
 
 On or after September 15, 2024, all newly-issued Publicly-Trusted end entity S/MIME Certificates SHALL be issued from S/MIME Subordinate CAs that are compliant with these Requirements.
 
-For backwards compatibility, Extant S/MIME CA Certificates that share the same Public Keys with S/MIME Subordinate CAs that are compliant with these Requirements, or are no longer used for signing end entity S/MIME Certificates, are not required to be revoked, with the exeption of the required revocation of any Certificate contains containing `RSASSA-PKCS1-v1_5 with SHA-1` as per [Section 7.1.3.1.1](#71311-rsa).
+For backwards compatibility, Extant S/MIME CA Certificates that share the same Public Keys with S/MIME Subordinate CAs that are compliant with these Requirements, or are no longer used for signing end entity S/MIME Certificates, are not required to be revoked, with the exception of the required revocation of any Certificate containing `RSASSA-PKCS1-v1_5 with SHA-1` as described in [Section 7.1.3.1.1](#71311-rsa).

--- a/SBR.md
+++ b/SBR.md
@@ -2096,9 +2096,9 @@ The CA SHALL NOT use a different algorithm, such as the id-RSASSA-PSS (OID: 1.2.
 
 When encoded, the `AlgorithmIdentifier` for RSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes: `300d06092a864886f70d0101010500`
 
-Effective September 15, 2026 the CA MUST NOT use the following signature algorithm and encoding: RSASSA-PKCS1-v1_5 with SHA-1
+Effective September 15, 2026 the CA MUST NOT use the following signature algorithm and encoding: RSASSA-PKCS1-v1_5 with SHA-1.
 
-Prior to September 15, 2026 the CA SHALL revoke any unexpired Subordinate CA Certificate that contains `RSASSA-PKCS1-v1_5 with SHA-1` within the Certificate.
+Prior to September 15, 2026 the CA SHALL revoke any unexpired Subordinate CA Certificate that contains RSASSA-PKCS1-v1_5 with SHA-1 within the Certificate.
 
 ##### 7.1.3.1.2 ECDSA
 
@@ -2138,7 +2138,7 @@ The CA SHALL indicate an ML-DSA key using one of the following algorithm identif
 
 The parameters for ML-DSA keys SHALL be absent. The CA MUST NOT use HashML-DSA; only "pure" ML-DSA is permitted.
 
-When encoded, the AlgorithmIdentifier for ML-DSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
+When encoded, the `AlgorithmIdentifier` for ML-DSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
 
 * For ML-DSA-44, `300b0609608648016503040311`.
 * For ML-DSA-65, `300b0609608648016503040312`.
@@ -2154,7 +2154,7 @@ The CA SHALL indicate an ML-KEM key using one of the following algorithm identif
 
 The parameters for ML-KEM keys SHALL be absent.
 
-When encoded, the AlgorithmIdentifier for ML-KEM keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
+When encoded, the `AlgorithmIdentifier` for ML-KEM keys SHALL be byte-for-byte identical with the following hex-encoded bytes:
 
 * For ML-KEM-512, `300b0609608648016503040401`.
 * For ML-KEM-768, `300b0609608648016503040402`.
@@ -3008,4 +3008,4 @@ Following the Effective Date for v 1.0.0 of these Requirements (September 1, 202
 
 On or after September 15, 2024, all newly-issued Publicly-Trusted end entity S/MIME Certificates SHALL be issued from S/MIME Subordinate CAs that are compliant with these Requirements.
 
-For backwards compatibility, Extant S/MIME CA Certificates that share the same Public Keys with S/MIME Subordinate CAs that are compliant with these Requirements, or are no longer used for signing end entity S/MIME Certificates, are not required to be revoked, with the exception of the required revocation of any Certificate containing `RSASSA-PKCS1-v1_5 with SHA-1` as described in [Section 7.1.3.1.1](#71311-rsa).
+For backwards compatibility, Extant S/MIME CA Certificates that share the same Public Keys with S/MIME Subordinate CAs that are compliant with these Requirements, or are no longer used for signing end entity S/MIME Certificates, are not required to be revoked, with the exception of the required revocation of any Certificate containing RSASSA-PKCS1-v1_5 with SHA-1 as described in [Section 7.1.3.1.1](#71311-rsa).

--- a/SBR.md
+++ b/SBR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted S/MIME Certificates
-subtitle: Version 1.0.12
+subtitle: Version 1.0.14
 author:
   - CA/Browser Forum
-date: October 13, 2025
+date: TBD
 copyright: |
-  Copyright 2025 CA/Browser Forum
+  Copyright 2026 CA/Browser Forum
   This work is licensed under the Creative Commons Attribution 4.0 International license.
 ---
 
@@ -90,7 +90,8 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.9   | SMC011   |Add EUID as Registration Reference | May 14, 2025 |
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
-| 1.0.12  | SMC013   |DNSSEC for CAA | October 13, 2025 |
+| 1.0.12  | SMC014   |DNSSEC for CAA | October 13, 2025 |
+| 1.0.14  | SMC016   |Ballots SC096 and SC097 | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 

--- a/SBR.md
+++ b/SBR.md
@@ -2096,9 +2096,9 @@ The CA SHALL NOT use a different algorithm, such as the id-RSASSA-PSS (OID: 1.2.
 
 When encoded, the `AlgorithmIdentifier` for RSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes: `300d06092a864886f70d0101010500`
 
-Effective September 15, 2026 the CA MUST NOT use the following signature algorithm and encoding: RSASSA-PKCS1-v1_5 with SHA-1.
+Effective September 15, 2026 the CA MUST NOT sign a certificate using a signature algorithm that incorporates SHA-1.
 
-Prior to September 15, 2026 the CA SHALL revoke any unexpired Subordinate CA Certificate that contains RSASSA-PKCS1-v1_5 with SHA-1 within the Certificate.
+Prior to September 15, 2026 the CA SHALL revoke any unexpired Subordinate CA Certificate whose signature algorithm incorporates SHA-1.
 
 ##### 7.1.3.1.2 ECDSA
 
@@ -3008,4 +3008,4 @@ Following the Effective Date for v 1.0.0 of these Requirements (September 1, 202
 
 On or after September 15, 2024, all newly-issued Publicly-Trusted end entity S/MIME Certificates SHALL be issued from S/MIME Subordinate CAs that are compliant with these Requirements.
 
-For backwards compatibility, Extant S/MIME CA Certificates that share the same Public Keys with S/MIME Subordinate CAs that are compliant with these Requirements, or are no longer used for signing end entity S/MIME Certificates, are not required to be revoked, with the exception of the required revocation of any Certificate containing RSASSA-PKCS1-v1_5 with SHA-1 as described in [Section 7.1.3.1.1](#71311-rsa).
+For backwards compatibility, Extant S/MIME CA Certificates that share the same Public Keys with S/MIME Subordinate CAs that are compliant with these Requirements, or are no longer used for signing end entity S/MIME Certificates, are not required to be revoked, with the exception of the required revocation of any Certificate whose signature algorithm incorporates SHA-1 as described in [Section 7.1.3.1.1](#71311-rsa).

--- a/SBR.md
+++ b/SBR.md
@@ -2096,7 +2096,7 @@ The CA SHALL NOT use a different algorithm, such as the id-RSASSA-PSS (OID: 1.2.
 
 When encoded, the `AlgorithmIdentifier` for RSA keys SHALL be byte-for-byte identical with the following hex-encoded bytes: `300d06092a864886f70d0101010500`
 
-Effective September 15, 2026 the CA MUST NOT sign a certificate using a signature algorithm that incorporates SHA-1.
+Effective September 15, 2026 the CA SHALL NOT sign a certificate using a signature algorithm that incorporates SHA-1.
 
 Prior to September 15, 2026 the CA SHALL revoke any unexpired Subordinate CA Certificate whose signature algorithm incorporates SHA-1.
 

--- a/SBR.md
+++ b/SBR.md
@@ -981,6 +981,8 @@ DNSSEC validation back to the IANA DNSSEC root trust anchor MAY be performed on 
 
 DNSSEC validation back to the IANA DNSSEC root trust anchor is considered outside the scope of self-audits performed to fulfill the requirements in [Section 8.7](#87-self-audits).
 
+DNSSEC validation back to the IANA DNSSEC root trust anchor is considered outside the scope of the logging requirements of [Section 5.4.1](#541-types-of-events-recorded).
+
 #### 4.2.2.2 Multi-perspective issuance corroboration
 
 CAs SHOULD implement [Section 3.2.2.9](https://github.com/cabforum/servercert/blob/main/docs/BR.md#3229-multi-perspective-issuance-corroboration) of the TLS Baseline Requirements before March 15, 2025. Effective May 15, 2025 CAs SHALL implement [Section 3.2.2.9](https://github.com/cabforum/servercert/blob/main/docs/BR.md#3229-multi-perspective-issuance-corroboration) of the TLS Baseline Requirements. This optional delay to the Phased Implementation Timeline for MPIC is intended to assist S/MIME Certificate Issuers with no TLS MPIC obligations.  

--- a/SBR.md
+++ b/SBR.md
@@ -109,7 +109,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
-| 1.0.14 | SMC016 | SHALL all remaining use of SHA-1 in Certificates and CRLs | September 15, 2026 |
+| 1.0.14 | SMC016 | SHALL sunset all remaining use of SHA-1 in Certificates and CRLs | September 15, 2026 |
 
 ## 1.3 PKI participants
 


### PR DESCRIPTION
This ballot maintains consistency between the S/MIME Baseline Requirements and the TLS Baseline Requirements with changes introduced by Ballots SC096 and SC097.  Specifically, this ballot:

* Creates a carve-out of the logging requirements for DNSSEC specifically, stating these are not in scope. For audit purposes, change management logging is able to confirm if the appropriate controls are in effect or not.
* Sunsets all remaining use of SHA-1 signatures in Certificates and CRLs. It is noted that most uses of SHA-1 signatures are already deprecated by SC097. With this ballot, all unexpired Subordinate CA Certificates issuing S/MIME containing the SHA-1 signature algorithm must be revoked. This proposal does not prohibit the use of SHA-1 to generate issuerKeyHash or issuerNameHash values as currently required by RFC 5019.
* Includes minor formatting corrections.
