### PR TITLE
Ballot SMC017: Increase Minimum RSA CA Key Size

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -91,6 +91,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC013   |DNSSEC for CAA | October 13, 2025 |
+| 1.0.17  | SMC017   |Increase minimum RSA CA key size | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 
@@ -108,6 +109,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
+| 1.0.17  | SMC017   |Increase minimum RSA CA key size | TBD |
 
 ## 1.3 PKI participants
 

--- a/SBR.md
+++ b/SBR.md
@@ -1735,7 +1735,7 @@ No stipulation.
 
 For RSA key pairs the CA SHALL:
 
-* For Keys corresponding to Root and Subordinate CAs created after September 15, 2026 ensure that the modulus size, when encoded, is at least 4096 bits; and
+* For Keys corresponding to Root and Subordinate CA Certificates signed on or after September 15, 2026 ensure that the modulus size, when encoded, is at least 4096 bits; and
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
@@ -1747,7 +1747,7 @@ For ECDSA key pairs, the CA SHALL:
 
 For EdDSA key pairs, the CA SHALL:
 
-* Ensure that the key represents a valid point on the curve25519 or curve 448 elliptic curve.
+* Ensure that the key represents a valid point on the curve25519 or curve448 elliptic curve.
 
 For ML-DSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -91,7 +91,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC013   |DNSSEC for CAA | October 13, 2025 |
-| 1.0.17  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
+| 1.0.15  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 
@@ -109,8 +109,8 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
-| 1.0.17  | SMC017   |New Root or Subordinate CA RSA Key SHALL be at least 3072 bits | September 15, 2026 |
-| 1.0.17  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2028 |
+| 1.0.15  | SMC017   |New Root or Subordinate CA RSA Key SHALL be at least 4096 bits | September 15, 2026 |
+| 1.0.15  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 4096 bits | September 15, 2027 |
 
 ## 1.3 PKI participants
 
@@ -1697,11 +1697,11 @@ No stipulation.
 
 For RSA key pairs the CA SHALL:
 
-* For Keys corresponding to Root and Subordinate CAs created after September 15, 2026 ensure that the modulus size, when encoded, is at least 3072 bits; and
+* For Keys corresponding to Root and Subordinate CAs created after September 15, 2026 ensure that the modulus size, when encoded, is at least 4096 bits; and
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2028 the CA SHALL NOT issue Certificates from any Subordinate CA whose RSA Key modulus size, when encoded, is less than 3072 bits.
+Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA whose RSA Key modulus size, when encoded, is less than 4096 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -1700,6 +1700,8 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
+Effective September 15, 2028 the CA SHALL cease issuance using Subordinate CAs whose RSA Key modulus size, when encoded, is at less than 3072 bits.
+
 For ECDSA key pairs, the CA SHALL:
 
 * Ensure that the key represents a valid point on the NIST P-256, NIST P-384, or NIST P-521 elliptic curve.

--- a/SBR.md
+++ b/SBR.md
@@ -1701,7 +1701,7 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2028 the CA SHALL cease issuance using Subordinate CAs whose RSA Key modulus size, when encoded, is less than 3072 bits.
+Effective September 15, 2028 the CA SHALL NOT issue Certificates from any Subordinate CA whose RSA Key modulus size, when encoded, is less than 3072 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -109,7 +109,8 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
-| 1.0.17  | SMC017   |Increase minimum RSA CA key size | TBD |
+| 1.0.17  | SMC017   |New Root and Subordinate CA RSA Key SHALL be at least 3072 bits | September 15, 2026 |
+| 1.0.17  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2028 |
 
 ## 1.3 PKI participants
 

--- a/SBR.md
+++ b/SBR.md
@@ -91,8 +91,8 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC014   |DNSSEC for CAA | October 13, 2025 |
-| 1.0.15  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
 | 1.0.13  | SMC015   |Allow mDL for Authentication of Individual Identity | March 27, 2026 |
+| 1.0.15  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 

--- a/SBR.md
+++ b/SBR.md
@@ -109,7 +109,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
-| 1.0.17  | SMC017   |New Root and Subordinate CA RSA Key SHALL be at least 3072 bits | September 15, 2026 |
+| 1.0.17  | SMC017   |New Root or Subordinate CA RSA Key SHALL be at least 3072 bits | September 15, 2026 |
 | 1.0.17  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2028 |
 
 ## 1.3 PKI participants

--- a/SBR.md
+++ b/SBR.md
@@ -1743,7 +1743,10 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA whose RSA Key modulus size, when encoded, is less than 4096 bits.
+Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA when:
+- the `tbsCertificate` contains the `extKeyUsage` extension with the value of `id-kp-emailProtection`;
+- the `tbsCertificate` contains `rfc822Name` or an `otherName` of type `id-on-SmtpUTF8Mailbox` in the `subjectAltName` extension., and;
+- the CA Certificates RSA Key modulus size, when encoded, is less than 3072 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted S/MIME Certificates
-subtitle: Version 1.0.12
+subtitle: Version 1.0.15
 author:
   - CA/Browser Forum
-date: October 13, 2025
+date: TBD
 copyright: |
-  Copyright 2025 CA/Browser Forum
+  Copyright 2026 CA/Browser Forum
   This work is licensed under the Creative Commons Attribution 4.0 International license.
 ---
 

--- a/SBR.md
+++ b/SBR.md
@@ -1744,9 +1744,9 @@ For RSA key pairs the CA SHALL:
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
 Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA when:
-- the `tbsCertificate` contains the `extKeyUsage` extension with the value of `id-kp-emailProtection`;
-- the `tbsCertificate` contains `rfc822Name` or an `otherName` of type `id-on-SmtpUTF8Mailbox` in the `subjectAltName` extension., and;
-- the CA Certificates RSA Key modulus size, when encoded, is less than 3072 bits.
+- the `tbsCertificate` contains `id-kp-emailProtection` in the `extKeyUsage` extension; and
+- the `tbsCertificate` contains a `subjectAltName` extension that complies with [Section 7.1.4.2.1](#71421-subject-alternative-name-extension); and
+- the CA Certificate's RSA Key modulus size, when encoded, is less than 3072 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -1700,7 +1700,7 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2028 the CA SHALL cease issuance using Subordinate CAs whose RSA Key modulus size, when encoded, is at less than 3072 bits.
+Effective September 15, 2028 the CA SHALL cease issuance using Subordinate CAs whose RSA Key modulus size, when encoded, is less than 3072 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -91,7 +91,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC013   |DNSSEC for CAA | October 13, 2025 |
-| 1.0.17  | SMC017   |Increase minimum RSA CA key size | TBD |
+| 1.0.17  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 
@@ -1696,7 +1696,8 @@ No stipulation.
 
 For RSA key pairs the CA SHALL:
 
-* Ensure that the modulus size, when encoded, is at least 2048 bits; and
+* For Keys corresponding to Root and Subordinate CAs created after September 15, 2026 ensure that the modulus size, when encoded, is at least 3072 bits; and
+* For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
 For ECDSA key pairs, the CA SHALL:


### PR DESCRIPTION
This ballot increases the minimum RSA key size for Root and Subordinate CA certificates in the S/MIME BRs from 2048 to 4096 bits for keys created after September 15, 2026, while retaining the 2048-bit minimum for Subscriber certificates. 

The ballot further requires that by September 15, 2027, CAs SHALL NOT issue certificates from any Sub-CA whose RSA key modulus is less than 4096 bits, effectively sunsetting issuance from legacy 2048-bit Sub-CAs.

This ballot is proposed by Stephen Davidson (DigiCert) and endorsed by Ben Wilson (Mozilla) and Roman Fischer (SwissSign).
