### PR TITLE
Ballot SMC017v2: Increase Minimum RSA CA Key Size

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -1739,7 +1739,7 @@ No stipulation.
 
 For RSA key pairs the CA SHALL:
 
-* For Keys corresponding to Root and Subordinate CA Certificates signed on or after September 15, 2026 ensure that the modulus size, when encoded, is at least 4096 bits; and
+* For Keys corresponding to CA Certificates (including Root, Subordinate and Cross Certificates) signed on or after September 15, 2026 ensure that the modulus size, when encoded, is at least 4096 bits; and
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 

--- a/SBR.md
+++ b/SBR.md
@@ -1743,10 +1743,12 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA when:
+Effective September 15, 2027 the CA SHALL NOT issue Certificates from any CA when:
 - the `tbsCertificate` contains `id-kp-emailProtection` in the `extKeyUsage` extension; and
 - the `tbsCertificate` contains a `subjectAltName` extension that complies with [Section 7.1.4.2.1](#71421-subject-alternative-name-extension); and
 - the CA Certificate's RSA Key modulus size, when encoded, is less than 3072 bits.
+
+**Note:** The paragraph above intends to prevent the issuance of S/MIME Subscriber Certificates by existing Subordinate CAs which have an RSA key size of less than 3072 bits. The issuance of Delegated OCSP Signing Certificates by these CAs remains permitted. 
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -91,6 +91,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC013   |DNSSEC for CAA | October 13, 2025 |
+| 1.0.17  | SMC017   |Increase minimum RSA CA key size | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 
@@ -108,6 +109,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
+| 1.0.17  | SMC017   |Increase minimum RSA CA key size | TBD |
 
 ## 1.3 PKI participants
 

--- a/SBR.md
+++ b/SBR.md
@@ -1735,7 +1735,7 @@ No stipulation.
 
 For RSA key pairs the CA SHALL:
 
-* For Keys corresponding to Root and Subordinate CAs created after September 15, 2026 ensure that the modulus size, when encoded, is at least 4096 bits; and
+* For Keys corresponding to Root and Subordinate CA Certificates signed on or after September 15, 2026 ensure that the modulus size, when encoded, is at least 4096 bits; and
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
@@ -1747,7 +1747,7 @@ For ECDSA key pairs, the CA SHALL:
 
 For EdDSA key pairs, the CA SHALL:
 
-* Ensure that the key represents a valid point on the curve25519 or curve 448 elliptic curve.
+* Ensure that the key represents a valid point on the curve25519 or curve448 elliptic curve.
 
 For ML-DSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -91,7 +91,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC013   |DNSSEC for CAA | October 13, 2025 |
-| 1.0.17  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
+| 1.0.15  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 
@@ -109,8 +109,8 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
-| 1.0.17  | SMC017   |New Root or Subordinate CA RSA Key SHALL be at least 3072 bits | September 15, 2026 |
-| 1.0.17  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2028 |
+| 1.0.15  | SMC017   |New Root or Subordinate CA RSA Key SHALL be at least 4096 bits | September 15, 2026 |
+| 1.0.15  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 4096 bits | September 15, 2027 |
 
 ## 1.3 PKI participants
 
@@ -1697,11 +1697,11 @@ No stipulation.
 
 For RSA key pairs the CA SHALL:
 
-* For Keys corresponding to Root and Subordinate CAs created after September 15, 2026 ensure that the modulus size, when encoded, is at least 3072 bits; and
+* For Keys corresponding to Root and Subordinate CAs created after September 15, 2026 ensure that the modulus size, when encoded, is at least 4096 bits; and
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2028 the CA SHALL NOT issue Certificates from any Subordinate CA whose RSA Key modulus size, when encoded, is less than 3072 bits.
+Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA whose RSA Key modulus size, when encoded, is less than 4096 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -1700,6 +1700,8 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
+Effective September 15, 2028 the CA SHALL cease issuance using Subordinate CAs whose RSA Key modulus size, when encoded, is at less than 3072 bits.
+
 For ECDSA key pairs, the CA SHALL:
 
 * Ensure that the key represents a valid point on the NIST P-256, NIST P-384, or NIST P-521 elliptic curve.

--- a/SBR.md
+++ b/SBR.md
@@ -1701,7 +1701,7 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2028 the CA SHALL cease issuance using Subordinate CAs whose RSA Key modulus size, when encoded, is less than 3072 bits.
+Effective September 15, 2028 the CA SHALL NOT issue Certificates from any Subordinate CA whose RSA Key modulus size, when encoded, is less than 3072 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -1756,7 +1756,7 @@ For ECDSA key pairs, the CA SHALL:
 
 For EdDSA key pairs, the CA SHALL:
 
-* Ensure that the key represents a valid point on the curve25519 or curve448 elliptic curve.
+* Ensure that the key represents a valid point on the Curve25519 or Curve448 elliptic curve.
 
 For ML-DSA key pairs, the CA SHALL:
 
@@ -2167,8 +2167,8 @@ When encoded, the `AlgorithmIdentifier` for ECDSA keys SHALL be byte-for-byte id
 
 The CA SHALL indicate an EdDSA key using one of the following algorithm identifiers below:
 
-* For curve25519 keys, the `algorithm` SHALL be id-Ed25519 (OID: 1.3.101.112).
-* For curve448 keys, the `algorithm` SHALL be id-Ed448 (OID: 1.3.101.113).
+* For Curve25519 keys, the `algorithm` SHALL be id-Ed25519 (OID: 1.3.101.112).
+* For Curve448 keys, the `algorithm` SHALL be id-Ed448 (OID: 1.3.101.113).
 
 The parameters for EdDSA keys SHALL be absent.
 

--- a/SBR.md
+++ b/SBR.md
@@ -109,7 +109,8 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
-| 1.0.17  | SMC017   |Increase minimum RSA CA key size | TBD |
+| 1.0.17  | SMC017   |New Root and Subordinate CA RSA Key SHALL be at least 3072 bits | September 15, 2026 |
+| 1.0.17  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2028 |
 
 ## 1.3 PKI participants
 

--- a/SBR.md
+++ b/SBR.md
@@ -91,8 +91,8 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC014   |DNSSEC for CAA | October 13, 2025 |
-| 1.0.15  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
 | 1.0.13  | SMC015   |Allow mDL for Authentication of Individual Identity | March 27, 2026 |
+| 1.0.15  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 

--- a/SBR.md
+++ b/SBR.md
@@ -109,7 +109,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.8 | SMC010 | SHOULD implement MPIC | March 15, 2025 |
 | 1.0.8 | SMC010 | SHALL implement MPIC | May 15, 2025 |
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
-| 1.0.17  | SMC017   |New Root and Subordinate CA RSA Key SHALL be at least 3072 bits | September 15, 2026 |
+| 1.0.17  | SMC017   |New Root or Subordinate CA RSA Key SHALL be at least 3072 bits | September 15, 2026 |
 | 1.0.17  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2028 |
 
 ## 1.3 PKI participants

--- a/SBR.md
+++ b/SBR.md
@@ -3,7 +3,7 @@ title: Baseline Requirements for the Issuance and Management of Publicly-Trusted
 subtitle: Version 1.0.15
 author:
   - CA/Browser Forum
-date: TBD
+date: July 30, 2026
 copyright: |
   Copyright 2026 CA/Browser Forum
   This work is licensed under the Creative Commons Attribution 4.0 International license.
@@ -93,7 +93,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.12  | SMC014   |DNSSEC for CAA | October 13, 2025 |
 | 1.0.13  | SMC015   |Allow mDL for Authentication of Individual Identity | March 27, 2026 |
 | 1.0.14  | SMC016   |Equivalence with Ballots SC096 and SC097 | May 5, 2026 |
-| 1.0.15  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
+| 1.0.15  | SMC017   |Increase Minimum RSA CA Key Size | July 30, 2026 |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 

--- a/SBR.md
+++ b/SBR.md
@@ -1743,7 +1743,7 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2027 the CA SHALL NOT issue Certificates from any CA when:
+Effective September 15, 2027 the CA SHALL NOT issue Certificates from any CA if all of the following conditions are true:
 - the `tbsCertificate` contains `id-kp-emailProtection` in the `extKeyUsage` extension; and
 - the `tbsCertificate` contains a `subjectAltName` extension that complies with [Section 7.1.4.2.1](#71421-subject-alternative-name-extension); and
 - the CA Certificate's RSA Key modulus size, when encoded, is less than 3072 bits.

--- a/SBR.md
+++ b/SBR.md
@@ -1743,7 +1743,10 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA whose RSA Key modulus size, when encoded, is less than 4096 bits.
+Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA when:
+- the `tbsCertificate` contains the `extKeyUsage` extension with the value of `id-kp-emailProtection`;
+- the `tbsCertificate` contains `rfc822Name` or an `otherName` of type `id-on-SmtpUTF8Mailbox` in the `subjectAltName` extension., and;
+- the CA Certificates RSA Key modulus size, when encoded, is less than 3072 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -113,7 +113,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
 | 1.0.14 | SMC016 | SHALL sunset all remaining use of SHA-1 in Certificates and CRLs | September 15, 2026 |
 | 1.0.15  | SMC017   |New Root or Subordinate CA RSA Key SHALL be at least 4096 bits | September 15, 2026 |
-| 1.0.15  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2027 |
+| 1.0.15  | SMC017   |SHALL cease Subscriber Certificate issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2027 |
 
 ## 1.3 PKI participants
 

--- a/SBR.md
+++ b/SBR.md
@@ -113,7 +113,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.12 | SMC014 | SHALL implement DNSSEC for CAA | March 15, 2026 |
 | 1.0.14 | SMC016 | SHALL sunset all remaining use of SHA-1 in Certificates and CRLs | September 15, 2026 |
 | 1.0.15  | SMC017   |New Root or Subordinate CA RSA Key SHALL be at least 4096 bits | September 15, 2026 |
-| 1.0.15  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 4096 bits | September 15, 2027 |
+| 1.0.15  | SMC017   |SHALL cease issuance from Subordinate CA with RSA Key less than 3072 bits | September 15, 2027 |
 
 ## 1.3 PKI participants
 

--- a/SBR.md
+++ b/SBR.md
@@ -1,11 +1,11 @@
 ---
 title: Baseline Requirements for the Issuance and Management of Publicly-Trusted S/MIME Certificates
-subtitle: Version 1.0.12
+subtitle: Version 1.0.15
 author:
   - CA/Browser Forum
-date: October 13, 2025
+date: TBD
 copyright: |
-  Copyright 2025 CA/Browser Forum
+  Copyright 2026 CA/Browser Forum
   This work is licensed under the Creative Commons Attribution 4.0 International license.
 ---
 

--- a/SBR.md
+++ b/SBR.md
@@ -1744,9 +1744,9 @@ For RSA key pairs the CA SHALL:
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
 Effective September 15, 2027 the CA SHALL NOT issue Certificates from any Subordinate CA when:
-- the `tbsCertificate` contains the `extKeyUsage` extension with the value of `id-kp-emailProtection`;
-- the `tbsCertificate` contains `rfc822Name` or an `otherName` of type `id-on-SmtpUTF8Mailbox` in the `subjectAltName` extension., and;
-- the CA Certificates RSA Key modulus size, when encoded, is less than 3072 bits.
+- the `tbsCertificate` contains `id-kp-emailProtection` in the `extKeyUsage` extension; and
+- the `tbsCertificate` contains a `subjectAltName` extension that complies with [Section 7.1.4.2.1](#71421-subject-alternative-name-extension); and
+- the CA Certificate's RSA Key modulus size, when encoded, is less than 3072 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -1700,7 +1700,7 @@ For RSA key pairs the CA SHALL:
 * For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
-Effective September 15, 2028 the CA SHALL cease issuance using Subordinate CAs whose RSA Key modulus size, when encoded, is at less than 3072 bits.
+Effective September 15, 2028 the CA SHALL cease issuance using Subordinate CAs whose RSA Key modulus size, when encoded, is less than 3072 bits.
 
 For ECDSA key pairs, the CA SHALL:
 

--- a/SBR.md
+++ b/SBR.md
@@ -91,7 +91,7 @@ The following Certificate Policy identifiers are reserved for use by CAs as a me
 | 1.0.10  | SMC012   |ACME for S/MIME Automation | July 2, 2025 |
 | 1.0.11  | SMC013   |Introduction of PQC Algorithms | August 22, 2025 |
 | 1.0.12  | SMC013   |DNSSEC for CAA | October 13, 2025 |
-| 1.0.17  | SMC017   |Increase minimum RSA CA key size | TBD |
+| 1.0.17  | SMC017   |Increase Minimum RSA CA Key Size | TBD |
 
 \* Publication Date is the date the new version was published following the Intellectual Property Review.
 
@@ -1696,7 +1696,8 @@ No stipulation.
 
 For RSA key pairs the CA SHALL:
 
-* Ensure that the modulus size, when encoded, is at least 2048 bits; and
+* For Keys corresponding to Root and Subordinate CAs created after September 15, 2026 ensure that the modulus size, when encoded, is at least 3072 bits; and
+* For Keys corresponding to Subscriber Certificates, ensure that the modulus size, when encoded, is at least 2048 bits; and
 * Ensure that the modulus size, in bits, is evenly divisible by 8.
 
 For ECDSA key pairs, the CA SHALL:


### PR DESCRIPTION
This PR is a refinement of https://github.com/cabforum/smime/pull/303, and more specifically carves out what type of certificate can no longer be issued from CAs not matching the required key size. 

Additionally I am proposing we keep the new CA issuance limit at RSA 4096 bits, but allow RSA 3072 bits CAs to keep being allowed to issue new certificates for the moment